### PR TITLE
naver oauth login 객체 구조분해 error 수정

### DIFF
--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -7,7 +7,7 @@ const naverLogin = (req, res, next) => {
       ? process.env.CLIENT_DOMAIN_DEVELOP
       : process.env.CLIENT_DOMAIN_PRODUCTION;
   try {
-    const user = { req };
+    const { user } = req;
     const token = createJWT(user);
     res.header('Authentication', token);
     res.status(200).redirect(`${clientURL}?token=${token}`);


### PR DESCRIPTION
`user= { req }` => `{ user } = req`

오타가 있어서 서버에 배포할 때, 문제가 있었습니다.