### PR TITLE
popover 모달 추가

### DIFF
--- a/iOS/HalgoraeDO.xcodeproj/project.pbxproj
+++ b/iOS/HalgoraeDO.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		4CCD320E256EBD4600A46D10 /* TaskListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3F566E256B8C2B006D7C9F /* TaskListInteractor.swift */; };
 		4CCD3248256F847800A46D10 /* PopoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCD3247256F847800A46D10 /* PopoverViewController.swift */; };
 		4CCD324E256F84BD00A46D10 /* PopoverViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCD324D256F84BD00A46D10 /* PopoverViewModelType.swift */; };
+		4CCD325E256F8C1200A46D10 /* UIImage+scaled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCD325D256F8C1200A46D10 /* UIImage+scaled.swift */; };
 		AAEE20DE2564E4A900668FAD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE20DD2564E4A900668FAD /* AppDelegate.swift */; };
 		AAEE20E02564E4A900668FAD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE20DF2564E4A900668FAD /* SceneDelegate.swift */; };
 		AAEE20E52564E4AA00668FAD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AAEE20E32564E4AA00668FAD /* Main.storyboard */; };
@@ -73,6 +74,7 @@
 		4CCD3242256F83BF00A46D10 /* TaskListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TaskListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CCD3247256F847800A46D10 /* PopoverViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverViewController.swift; sourceTree = "<group>"; };
 		4CCD324D256F84BD00A46D10 /* PopoverViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverViewModelType.swift; sourceTree = "<group>"; };
+		4CCD325D256F8C1200A46D10 /* UIImage+scaled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+scaled.swift"; sourceTree = "<group>"; };
 		AAEE20DD2564E4A900668FAD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AAEE20DF2564E4A900668FAD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		AAEE20E42564E4AA00668FAD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -188,6 +190,14 @@
 			path = Popover;
 			sourceTree = "<group>";
 		};
+		4CCD325C256F8BE600A46D10 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				4CCD325D256F8C1200A46D10 /* UIImage+scaled.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		AAEE20D12564E4A900668FAD = {
 			isa = PBXGroup;
 			children = (
@@ -221,6 +231,7 @@
 		AAEE21112564E57D00668FAD /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				4CCD325C256F8BE600A46D10 /* Utils */,
 				AAEE21102564E55500668FAD /* Entry */,
 				4C3F5693256BA21B006D7C9F /* Models */,
 				4CCD3245256F845C00A46D10 /* Common */,
@@ -377,6 +388,7 @@
 				4C3F5683256B8F4B006D7C9F /* TaskListRouter.swift in Sources */,
 				4C3F566A256B82F2006D7C9F /* TaskBoardViewController.swift in Sources */,
 				4C3F5665256B8117006D7C9F /* TaskListViewController.swift in Sources */,
+				4CCD325E256F8C1200A46D10 /* UIImage+scaled.swift in Sources */,
 				4C3F5700256CF8A7006D7C9F /* TaskContentConfigure.swift in Sources */,
 				4C3F5674256B8C63006D7C9F /* TaskListWorker.swift in Sources */,
 				4C3F566F256B8C2B006D7C9F /* TaskListInteractor.swift in Sources */,

--- a/iOS/HalgoraeDO.xcodeproj/project.pbxproj
+++ b/iOS/HalgoraeDO.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		4CCD3208256EBD3E00A46D10 /* TaskListWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3F5673256B8C63006D7C9F /* TaskListWorker.swift */; };
 		4CCD320B256EBD4200A46D10 /* TaskListDisplayLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0CA635256EAC5200E66045 /* TaskListDisplayLogic.swift */; };
 		4CCD320E256EBD4600A46D10 /* TaskListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3F566E256B8C2B006D7C9F /* TaskListInteractor.swift */; };
+		4CCD3248256F847800A46D10 /* PopoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCD3247256F847800A46D10 /* PopoverViewController.swift */; };
+		4CCD324E256F84BD00A46D10 /* PopoverViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCD324D256F84BD00A46D10 /* PopoverViewModelType.swift */; };
 		AAEE20DE2564E4A900668FAD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE20DD2564E4A900668FAD /* AppDelegate.swift */; };
 		AAEE20E02564E4A900668FAD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE20DF2564E4A900668FAD /* SceneDelegate.swift */; };
 		AAEE20E52564E4AA00668FAD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AAEE20E32564E4AA00668FAD /* Main.storyboard */; };
@@ -65,10 +67,12 @@
 		4C3F56FF256CF8A7006D7C9F /* TaskContentConfigure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskContentConfigure.swift; sourceTree = "<group>"; };
 		4C3F5704256CF8B9006D7C9F /* TaskContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskContentView.swift; sourceTree = "<group>"; };
 		4C3F573E256D2263006D7C9F /* RoundButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundButton.swift; sourceTree = "<group>"; };
-		4CCD31D9256EBC0000A46D10 /* TaskListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = TaskListTests.xctest; path = "/Users/os/woong/iOS/Boostcamp2020/group_final/Project04-C-Whale/iOS/build/Debug-iphoneos/TaskListTests.xctest"; sourceTree = "<absolute>"; };
 		4CCD31DD256EBC0000A46D10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4CCD31F8256EBC8000A46D10 /* TaskListDisplaySpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListDisplaySpy.swift; sourceTree = "<group>"; };
 		4CCD31FE256EBCEF00A46D10 /* TaskListPresenterSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListPresenterSpy.swift; sourceTree = "<group>"; };
+		4CCD3242256F83BF00A46D10 /* TaskListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TaskListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4CCD3247256F847800A46D10 /* PopoverViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverViewController.swift; sourceTree = "<group>"; };
+		4CCD324D256F84BD00A46D10 /* PopoverViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverViewModelType.swift; sourceTree = "<group>"; };
 		AAEE20DD2564E4A900668FAD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AAEE20DF2564E4A900668FAD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		AAEE20E42564E4AA00668FAD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -167,12 +171,30 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
+		4CCD3245256F845C00A46D10 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				4CCD3246256F846B00A46D10 /* Popover */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		4CCD3246256F846B00A46D10 /* Popover */ = {
+			isa = PBXGroup;
+			children = (
+				4CCD3247256F847800A46D10 /* PopoverViewController.swift */,
+				4CCD324D256F84BD00A46D10 /* PopoverViewModelType.swift */,
+			);
+			path = Popover;
+			sourceTree = "<group>";
+		};
 		AAEE20D12564E4A900668FAD = {
 			isa = PBXGroup;
 			children = (
 				AAEE20DC2564E4A900668FAD /* HalgoraeDO */,
 				4C3F5657256B80B4006D7C9F /* HalgoraeDO.app */,
 				4CCD31DA256EBC0000A46D10 /* TaskListTests */,
+				4CCD3242256F83BF00A46D10 /* TaskListTests.xctest */,
 			);
 			sourceTree = "<group>";
 		};
@@ -201,6 +223,7 @@
 			children = (
 				AAEE21102564E55500668FAD /* Entry */,
 				4C3F5693256BA21B006D7C9F /* Models */,
+				4CCD3245256F845C00A46D10 /* Common */,
 				4C3F55AD2564EE74006D7C9F /* Scenes */,
 				4C3F55B12564EEC6006D7C9F /* Views */,
 			);
@@ -241,7 +264,7 @@
 			);
 			name = TaskListTests;
 			productName = TaskListTests;
-			productReference = 4CCD31D9256EBC0000A46D10 /* TaskListTests.xctest */;
+			productReference = 4CCD3242256F83BF00A46D10 /* TaskListTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		AAEE20D92564E4A900668FAD /* HalgoraeDO */ = {
@@ -340,7 +363,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4CCD3248256F847800A46D10 /* PopoverViewController.swift in Sources */,
 				4C3F568C256B93D5006D7C9F /* TaskCollectionViewListCell.swift in Sources */,
+				4CCD324E256F84BD00A46D10 /* PopoverViewModelType.swift in Sources */,
 				4C3F5679256B8C83006D7C9F /* TaskListPresenter.swift in Sources */,
 				4C3F573F256D2263006D7C9F /* RoundButton.swift in Sources */,
 				AAEE20DE2564E4A900668FAD /* AppDelegate.swift in Sources */,

--- a/iOS/HalgoraeDO.xcodeproj/project.pbxproj
+++ b/iOS/HalgoraeDO.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		4CCD320E256EBD4600A46D10 /* TaskListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3F566E256B8C2B006D7C9F /* TaskListInteractor.swift */; };
 		4CCD3248256F847800A46D10 /* PopoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCD3247256F847800A46D10 /* PopoverViewController.swift */; };
 		4CCD324E256F84BD00A46D10 /* PopoverViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCD324D256F84BD00A46D10 /* PopoverViewModelType.swift */; };
+		4CCD3257256F8BA700A46D10 /* Priority.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCD3256256F8BA700A46D10 /* Priority.swift */; };
 		4CCD325E256F8C1200A46D10 /* UIImage+scaled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCD325D256F8C1200A46D10 /* UIImage+scaled.swift */; };
 		AAEE20DE2564E4A900668FAD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE20DD2564E4A900668FAD /* AppDelegate.swift */; };
 		AAEE20E02564E4A900668FAD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE20DF2564E4A900668FAD /* SceneDelegate.swift */; };
@@ -74,6 +75,7 @@
 		4CCD3242256F83BF00A46D10 /* TaskListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TaskListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CCD3247256F847800A46D10 /* PopoverViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverViewController.swift; sourceTree = "<group>"; };
 		4CCD324D256F84BD00A46D10 /* PopoverViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverViewModelType.swift; sourceTree = "<group>"; };
+		4CCD3256256F8BA700A46D10 /* Priority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Priority.swift; sourceTree = "<group>"; };
 		4CCD325D256F8C1200A46D10 /* UIImage+scaled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+scaled.swift"; sourceTree = "<group>"; };
 		AAEE20DD2564E4A900668FAD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AAEE20DF2564E4A900668FAD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				4C3F5694256BA228006D7C9F /* Task.swift */,
+				4CCD3256256F8BA700A46D10 /* Priority.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -392,6 +395,7 @@
 				4C3F5700256CF8A7006D7C9F /* TaskContentConfigure.swift in Sources */,
 				4C3F5674256B8C63006D7C9F /* TaskListWorker.swift in Sources */,
 				4C3F566F256B8C2B006D7C9F /* TaskListInteractor.swift in Sources */,
+				4CCD3257256F8BA700A46D10 /* Priority.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/HalgoraeDO/Sources/Common/Popover/PopoverViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Common/Popover/PopoverViewController.swift
@@ -1,0 +1,55 @@
+//
+//  PopoverViewController.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/11/26.
+//
+
+import UIKit
+
+class PopoverViewController: UIViewController {
+    
+    var viewModels = [PopoverViewModelType]()
+    var selectHandler: ((IndexPath) -> Void)?
+    /// default:  CGSize(width: 250, height: 44)
+    var cellSize: CGSize = CGSize(width: 250, height: 44)
+    
+    @IBOutlet weak private var tableView: UITableView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureContentSize()
+    }
+    
+    private func configureContentSize() {
+        preferredContentSize = CGSize(width: cellSize.width, height: cellSize.height * CGFloat(viewModels.count))
+    }
+}
+
+extension PopoverViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModels.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        let cell = tableView.dequeueReusableCell(withIdentifier: "popoverCell", for: indexPath)
+        let viewModel = viewModels[indexPath.row]
+        cell.textLabel?.text = viewModel.title
+        cell.imageView?.tintColor = viewModel.tintColor
+        cell.imageView?.image = viewModel.image
+        return cell
+    }
+}
+
+extension PopoverViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        selectHandler?(indexPath)
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return cellSize.height
+    }
+}

--- a/iOS/HalgoraeDO/Sources/Common/Popover/PopoverViewModelType.swift
+++ b/iOS/HalgoraeDO/Sources/Common/Popover/PopoverViewModelType.swift
@@ -1,0 +1,14 @@
+//
+//  PopoverViewModelType.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/11/26.
+//
+
+import UIKit
+
+protocol PopoverViewModelType {
+    var title: String { get set }
+    var tintColor: UIColor? { get set }
+    var image: UIImage? { get set }
+}

--- a/iOS/HalgoraeDO/Sources/Models/Priority.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Priority.swift
@@ -1,0 +1,44 @@
+//
+//  Priority.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/11/26.
+//
+
+import UIKit
+
+enum Priority: Int, CaseIterable {
+    case one = 1
+    case two
+    case three
+    case four
+    
+    var title: String {
+        switch self {
+            case .one: return "우선순위 1"
+            case .two: return "우선순위 2"
+            case .three: return "우선순위 3"
+            case .four: return "우선순위 4"
+        }
+    }
+}
+
+// MARK: - For PopoverViewModel
+
+extension Priority {
+    struct ViewModel: PopoverViewModelType {
+        var title: String
+        var tintColor: UIColor?
+        var image: UIImage?
+    }
+    
+    var viewModel: ViewModel {
+        let image = UIImage(named: "flag")?.scaled(to: .init(width: 30, height: 30))
+        switch self {
+            case .one: return ViewModel(title: title, tintColor: .red, image: image)
+            case .two: return ViewModel(title: title, tintColor: .blue, image: image)
+            case .three: return ViewModel(title: title, tintColor: .orange, image: image)
+            case .four: return ViewModel(title: title, tintColor: .black, image: image)
+        }
+    }
+}

--- a/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskBoardViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskBoardViewController.swift
@@ -75,6 +75,7 @@ private extension TaskBoardViewController {
         taskBoardCollectionView.dropDelegate = self
         taskBoardCollectionView.dragInteractionEnabled = true
         taskBoardCollectionView.collectionViewLayout = generateLayout()
+        taskBoardCollectionView.isPagingEnabled = true
     }
     
     private func generateLayout() -> UICollectionViewLayout {

--- a/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskBoardViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskBoardViewController.swift
@@ -48,6 +48,18 @@ class TaskBoardViewController: UIViewController {
 // MARK: - TaskList Display Logic
 
 extension TaskBoardViewController: TaskListDisplayLogic {
+    func displayDetail(of task: Task) {
+        
+    }
+    
+    func set(editingMode: Bool) {
+        
+    }
+    
+    func display(numberOfSelectedTasks count: Int) {
+        
+    }
+    
     func display(tasks: [Task]) {
         let snapShot = snapshot(taskItems: tasks)
         dataSource.apply(snapShot, animatingDifferences: false)
@@ -97,7 +109,7 @@ private extension TaskBoardViewController {
         let cellRegistration = UICollectionView.CellRegistration<TaskCollectionViewListCell, Task> { [weak self] (cell, indexPath, taskItem) in
             
             cell.task = taskItem
-            cell.completeHandler = { [weak self] task in
+            cell.finishHandler = { [weak self] task in
                 guard let self = self,
                       let task = task
                 else {

--- a/iOS/HalgoraeDO/Sources/Utils/UIImage+scaled.swift
+++ b/iOS/HalgoraeDO/Sources/Utils/UIImage+scaled.swift
@@ -1,0 +1,23 @@
+//
+//  UIImage+scaled.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/11/26.
+//
+
+import UIKit.UIImage
+
+extension UIImage {
+    
+    /// image를 주어진 size로 렌더링해서 반환합니다.
+    /// - Parameters:
+    ///   - size: 새로 draw할 size
+    ///   - renderingMode: default: alwaysTemplate
+    func scaled(to size: CGSize, renderingMode: RenderingMode = .alwaysTemplate) -> UIImage? {
+        UIGraphicsBeginImageContext(size)
+        self.draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return newImage?.withRenderingMode(renderingMode)
+    }
+}

--- a/iOS/HalgoraeDO/Sources/Views/Base.lproj/Main.storyboard
+++ b/iOS/HalgoraeDO/Sources/Views/Base.lproj/Main.storyboard
@@ -174,6 +174,53 @@
             </objects>
             <point key="canvasLocation" x="-636" y="86"/>
         </scene>
+        <!--Popover View Controller-->
+        <scene sceneID="Om4-0D-nar">
+            <objects>
+                <viewController id="swV-k3-g0c" customClass="PopoverViewController" customModule="HalgoraeDO" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="NGt-m8-MBb">
+                        <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="NQp-Hb-ZLp">
+                                <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="popoverCell" id="TMK-P1-C1S">
+                                        <rect key="frame" x="0.0" y="28" width="200" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TMK-P1-C1S" id="ikl-NK-mcb">
+                                            <rect key="frame" x="0.0" y="0.0" width="200" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="swV-k3-g0c" id="xrF-Ad-JAZ"/>
+                                    <outlet property="delegate" destination="swV-k3-g0c" id="zbf-TK-czk"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="4Oj-9z-E9f"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="4Oj-9z-E9f" firstAttribute="bottom" secondItem="NQp-Hb-ZLp" secondAttribute="bottom" id="9nH-cC-6Pb"/>
+                            <constraint firstItem="NQp-Hb-ZLp" firstAttribute="leading" secondItem="NGt-m8-MBb" secondAttribute="leading" id="W8b-Gm-HGb"/>
+                            <constraint firstAttribute="trailing" secondItem="NQp-Hb-ZLp" secondAttribute="trailing" id="oMN-eA-n2Z"/>
+                            <constraint firstItem="NQp-Hb-ZLp" firstAttribute="top" secondItem="NGt-m8-MBb" secondAttribute="top" id="yWG-kh-Ht7"/>
+                        </constraints>
+                    </view>
+                    <value key="contentSizeForViewInPopover" type="size" width="200" height="200"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="200" height="200"/>
+                    <connections>
+                        <outlet property="tableView" destination="NQp-Hb-ZLp" id="hUu-QB-fKP"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2y8-Po-Atx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="204" y="-607"/>
+        </scene>
         <!--View Controller-->
         <scene sceneID="RZa-X0-sHu">
             <objects>


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/23303023/100346651-88af9c00-3027-11eb-90bb-567f2df87dba.png" width="30%" />

### 작업내용
1. PopoverViewController 구현
2. Priority 모델 추가

### 코멘트
- PopoverViewModelType 타입의 데이터를 받아서 만들도록 구현해 재사용이 가능하도록 구현했습니다.
- 기본 셀을 사용했기 때문에 셀의 이미지 뷰의 크기를 직접 건드릴 수가 없었습니다. 그래서 이미지 크기를 조절해주는 방식으로 구현이 필요합니다. 이를 위해서 UIImage의 extension을 추가했습니다.

### 이슈번호
#58 