### PR TITLE
client Header -& 검색 컴포넌트 작업 && Task & User 리팩토링

### DIFF
--- a/client/src/api/myAxios.js
+++ b/client/src/api/myAxios.js
@@ -6,23 +6,23 @@ const headerConfig = {
   },
 };
 
-const BASE_URL = process.env.VUE_APP_SERVER_URL;
+const SERVER_URL = process.env.VUE_APP_SERVER_URL + "/api";
 
 const myAxios = {
   GET: (path) => {
-    return axios.get(BASE_URL + path, headerConfig);
+    return axios.get(SERVER_URL + path, headerConfig);
   },
   POST: (path, body) => {
-    return axios.post(BASE_URL + path, body, headerConfig);
+    return axios.post(SERVER_URL + path, body, headerConfig);
   },
   PATCH: (path, body) => {
-    return axios.patch(BASE_URL + path, body, headerConfig);
+    return axios.patch(SERVER_URL + path, body, headerConfig);
   },
   PUT: (path, body) => {
-    return axios.put(BASE_URL + path, body, headerConfig);
+    return axios.put(SERVER_URL + path, body, headerConfig);
   },
   DELETE: (path) => {
-    return axios.delete(BASE_URL + path, headerConfig);
+    return axios.delete(SERVER_URL + path, headerConfig);
   },
 };
 

--- a/client/src/api/myAxios.js
+++ b/client/src/api/myAxios.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const headerConfig = {
-  header: {
+  headers: {
     Authorization: `Bearer ${localStorage.getItem("token")}`,
   },
 };

--- a/client/src/api/task.js
+++ b/client/src/api/task.js
@@ -1,7 +1,7 @@
 import myAxios from "./myAxios";
 
 const taskAPI = {
-  searchTask() {
+  getAllTasks() {
     return myAxios.GET("/task");
   },
   updateTask(taskId, data) {

--- a/client/src/api/task.js
+++ b/client/src/api/task.js
@@ -1,9 +1,12 @@
 import myAxios from "./myAxios";
 
-const projectAPI = {
+const taskAPI = {
   updateTask(taskId, data) {
     return myAxios.PATCH(`/task/${taskId}`, data);
   },
+  serachTask(keyword, data) {
+    return myAxios.PATCH(`/task/serach?keyword=${keyword}`, data);
+  },
 };
 
-export default projectAPI;
+export default taskAPI;

--- a/client/src/api/task.js
+++ b/client/src/api/task.js
@@ -1,7 +1,7 @@
 import myAxios from "./myAxios";
 
 const taskAPI = {
-  serachTask() {
+  searchTask() {
     return myAxios.GET("/task");
   },
   updateTask(taskId, data) {

--- a/client/src/api/task.js
+++ b/client/src/api/task.js
@@ -1,11 +1,11 @@
 import myAxios from "./myAxios";
 
 const taskAPI = {
+  serachTask() {
+    return myAxios.GET("/task");
+  },
   updateTask(taskId, data) {
     return myAxios.PATCH(`/task/${taskId}`, data);
-  },
-  serachTask(keyword, data) {
-    return myAxios.PATCH(`/task/serach?keyword=${keyword}`, data);
   },
 };
 

--- a/client/src/components/common/Header.vue
+++ b/client/src/components/common/Header.vue
@@ -1,16 +1,23 @@
 <template>
-  <v-app-bar app color="primary" dark>
-    <div class="d-flex align-center">
-      <router-link to="/login">Login</router-link>
-      <router-link to="/today">Today</router-link>
-    </div>
-    <v-spacer></v-spacer>
-    <router-link to="project/1">Project</router-link>
-  </v-app-bar>
+  <v-container>
+    <v-navigation-drawer v-model="drawer" app>
+      <!-- <Menu /> -->
+    </v-navigation-drawer>
+    <v-app-bar app>
+      <v-app-bar-nav-icon @click="drawer = !drawer"></v-app-bar-nav-icon>
+      <v-toolbar-title>할고래DO</v-toolbar-title>
+      <serach-bar />
+    </v-app-bar>
+  </v-container>
 </template>
 
 <script>
+import Search from "../task/Search";
 export default {
   name: "Header",
+  data: () => ({ drawer: null }),
+  components: {
+    "serach-bar": Search,
+  },
 };
 </script>

--- a/client/src/components/task/Search.vue
+++ b/client/src/components/task/Search.vue
@@ -25,13 +25,15 @@
         solo
       ></v-text-field> -->
     </v-flex>
-    <!-- <v-container v-if="show">
+    <v-container v-if="show">
       <v-list v-for="task in lastSearched" :key="task.id">{{ task.title }}</v-list>
-    </v-container> -->
+    </v-container>
   </v-input>
 </template>
 
 <script>
+import router from "@/router/index.js";
+
 export default {
   data() {
     return {
@@ -60,6 +62,7 @@ export default {
     },
     items() {
       return this.entries.map((entry) => {
+        // TODO : API 연동 후, 변수명 title로 변경, entry에서도 title로 바꿔야한다.
         const Description =
           entry.Description.length > this.descriptionLimit
             ? entry.Description.slice(0, this.descriptionLimit) + "..."
@@ -71,16 +74,21 @@ export default {
   },
 
   watch: {
+    model(obj) {
+      //TODO API 연동 후, obj.id로 바뀌어야한다.
+      router.push(`/task/${obj.Description}`).catch(() => {});
+    },
     search() {
       // Items have already been loaded
-      if (this.items.length > 0) return;
-
-      // Items have already been requested
-      if (this.isLoading) return;
+      // or Items have already been requested
+      if (this.items.length > 0 || this.isLoading) {
+        return;
+      }
 
       this.isLoading = true;
 
-      // Lazily load input items, 여기에 serach 받아와서 표현
+      // Lazily load input items,
+      // TODO 여기에 serach 받아와서 표현 & axios로 바꿔야함
       fetch("https://api.publicapis.org/entries")
         .then((res) => res.json())
         .then((res) => {

--- a/client/src/components/task/Search.vue
+++ b/client/src/components/task/Search.vue
@@ -1,0 +1,100 @@
+<template>
+  <v-input>
+    <v-flex xs12 sm5 md3 ml-5 mt-12>
+      <v-card-text>
+        <v-autocomplete
+          v-model="model"
+          :items="items"
+          :loading="isLoading"
+          :search-input.sync="search"
+          color="green"
+          hide-no-data
+          hide-selected
+          item-text="Description"
+          item-value="API"
+          placeholder="검색"
+          prepend-icon="mdi-magnify"
+          return-object
+          solo
+        ></v-autocomplete>
+      </v-card-text>
+      <!-- <v-text-field
+        @click="show = !show"
+        appendIcon="mdi-magnify"
+        placeholder="검색"
+        solo
+      ></v-text-field> -->
+    </v-flex>
+    <!-- <v-container v-if="show">
+      <v-list v-for="task in lastSearched" :key="task.id">{{ task.title }}</v-list>
+    </v-container> -->
+  </v-input>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      show: false,
+      lastSearched: [
+        { id: "1212sdkf-124oij", title: "hi" },
+        { id: "12asd-1234", title: "test" },
+      ],
+      descriptionLimit: 60,
+      entries: [],
+      isLoading: false,
+      model: null,
+      search: null,
+    };
+  },
+  computed: {
+    fields() {
+      if (!this.model) return [];
+
+      return Object.keys(this.model).map((key) => {
+        return {
+          key,
+          value: this.model[key] || "n/a",
+        };
+      });
+    },
+    items() {
+      return this.entries.map((entry) => {
+        const Description =
+          entry.Description.length > this.descriptionLimit
+            ? entry.Description.slice(0, this.descriptionLimit) + "..."
+            : entry.Description; // display length 설정
+
+        return { Description, ...entry };
+      });
+    },
+  },
+
+  watch: {
+    search() {
+      // Items have already been loaded
+      if (this.items.length > 0) return;
+
+      // Items have already been requested
+      if (this.isLoading) return;
+
+      this.isLoading = true;
+
+      // Lazily load input items, 여기에 serach 받아와서 표현
+      fetch("https://api.publicapis.org/entries")
+        .then((res) => res.json())
+        .then((res) => {
+          const { count, entries } = res;
+          this.count = count;
+          this.entries = entries;
+        })
+        .catch((err) => {
+          console.log(err);
+        })
+        .finally(() => (this.isLoading = false));
+    },
+  },
+};
+</script>
+
+<style></style>

--- a/client/src/components/task/Search.vue
+++ b/client/src/components/task/Search.vue
@@ -10,7 +10,7 @@
           color="green"
           hide-no-data
           hide-selected
-          item-text="Description"
+          item-text="title"
           item-value="API"
           placeholder="검색"
           prepend-icon="mdi-magnify"
@@ -18,12 +18,6 @@
           solo
         ></v-autocomplete>
       </v-card-text>
-      <!-- <v-text-field
-        @click="show = !show"
-        appendIcon="mdi-magnify"
-        placeholder="검색"
-        solo
-      ></v-text-field> -->
     </v-flex>
     <v-container v-if="show">
       <v-list v-for="task in lastSearched" :key="task.id">{{ task.title }}</v-list>
@@ -33,17 +27,14 @@
 
 <script>
 import router from "@/router/index.js";
+import taskAPI from "@/api/task.js";
 
 export default {
   data() {
     return {
       show: false,
-      lastSearched: [
-        { id: "1212sdkf-124oij", title: "hi" },
-        { id: "12asd-1234", title: "test" },
-      ],
-      descriptionLimit: 60,
-      entries: [],
+      titleLimit: 60,
+      tasks: [],
       isLoading: false,
       model: null,
       search: null,
@@ -61,24 +52,22 @@ export default {
       });
     },
     items() {
-      return this.entries.map((entry) => {
-        // TODO : API 연동 후, 변수명 title로 변경, entry에서도 title로 바꿔야한다.
-        const Description =
-          entry.Description.length > this.descriptionLimit
-            ? entry.Description.slice(0, this.descriptionLimit) + "..."
-            : entry.Description; // display length 설정
+      return this.tasks.map((task) => {
+        const title =
+          task.title.length > this.titleLimit
+            ? task.title.slice(0, this.titleLimit) + "..."
+            : task.title; // display length 설정
 
-        return { Description, ...entry };
+        return { title, ...task };
       });
     },
   },
 
   watch: {
     model(obj) {
-      //TODO API 연동 후, obj.id로 바뀌어야한다.
-      router.push(`/task/${obj.Description}`).catch(() => {});
+      router.push(`/task/${obj.id}`).catch(() => {});
     },
-    search() {
+    async search() {
       // Items have already been loaded
       // or Items have already been requested
       if (this.items.length > 0 || this.isLoading) {
@@ -88,18 +77,10 @@ export default {
       this.isLoading = true;
 
       // Lazily load input items,
-      // TODO 여기에 serach 받아와서 표현 & axios로 바꿔야함
-      fetch("https://api.publicapis.org/entries")
-        .then((res) => res.json())
-        .then((res) => {
-          const { count, entries } = res;
-          this.count = count;
-          this.entries = entries;
-        })
-        .catch((err) => {
-          console.log(err);
-        })
-        .finally(() => (this.isLoading = false));
+      const res = await taskAPI.serachTask();
+
+      this.tasks = res.data.tasks;
+      this.isLoading = false;
     },
   },
 };

--- a/client/src/components/task/Search.vue
+++ b/client/src/components/task/Search.vue
@@ -77,7 +77,7 @@ export default {
       this.isLoading = true;
 
       // Lazily load input items,
-      const res = await taskAPI.searchTask();
+      const res = await taskAPI.getAllTasks();
       this.tasks = res.data.tasks;
       this.isLoading = false;
     },

--- a/client/src/components/task/Search.vue
+++ b/client/src/components/task/Search.vue
@@ -77,8 +77,7 @@ export default {
       this.isLoading = true;
 
       // Lazily load input items,
-      const res = await taskAPI.serachTask();
-
+      const res = await taskAPI.searchTask();
       this.tasks = res.data.tasks;
       this.isLoading = false;
     },

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -1,15 +1,8 @@
 <template>
   <v-app>
-    <v-navigation-drawer v-model="drawer" app>
-      <!-- <Menu /> -->
-    </v-navigation-drawer>
-    <v-app-bar app>
-      <v-app-bar-nav-icon @click="drawer = !drawer"></v-app-bar-nav-icon>
-
-      <v-toolbar-title>할고래DO</v-toolbar-title>
-    </v-app-bar>
+    <my-header />
     <!-- Sizes your content based upon application components -->
-    <v-main>
+    <v-main class="pt-0">
       <!-- Provides the application the proper gutter -->
       <v-container class="pa-15" fill-height>
         <!-- If using vue-router -->
@@ -20,13 +13,12 @@
 </template>
 
 <script>
-// import Menu from "../components/menu";
+import Header from "../components/common/Header";
 
 export default {
   name: "Home",
   components: {
-    // Menu,
+    "my-header": Header,
   },
-  data: () => ({ drawer: null }),
 };
 </script>

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   transpileDependencies: ["vuetify"],
-  lintOnSave: false
+  lintOnSave: false,
 };

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
       "^@utils/(.*)$": "<rootDir>/src/utils/$1",
       "^@routes(.*)$": "<rootDir>/src/routes/$1",
       "^@routes/(.*)$": "<rootDir>/src/routes/$1",
+      "^@services/(.*)$": "<rootDir>/src/services/$1",
       "^@controllers/(.*)$": "<rootDir>/src/controllers/$1",
       "^@passport(.*)$": "<rootDir>/src/passport/$1",
       "^@passport/(.*)$": "<rootDir>/src/passport/$1"

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -7,7 +7,8 @@ const loader = require('@root/loaders');
 const startServer = () => {
   const app = express();
   loader(app);
-  app.listen(process.env.PORT);
+  const port = process.env.NODE_ENV === 'test' ? process.env.TEST_PORT : process.env.PORT;
+  app.listen(port);
   return app;
 };
 

--- a/server/src/controllers/comment.js
+++ b/server/src/controllers/comment.js
@@ -1,0 +1,29 @@
+const commentService = require('@services/comment');
+const { asyncTryCatch } = require('@utils/async-try-catch');
+const { responseHandler } = require('@utils/handler');
+
+const getComments = asyncTryCatch(async (req, res) => {
+  const comments = await commentService.retrieveAllByTaskId(req.params.taskId);
+
+  responseHandler(res, 200, comments);
+});
+
+const createComment = asyncTryCatch(async (req, res) => {
+  await commentService.create(req.params.taskId, req.body);
+
+  responseHandler(res, 201, { message: 'ok' });
+});
+
+const updateComment = asyncTryCatch(async (req, res) => {
+  await commentService.update(req.params.commentId, req.body);
+
+  responseHandler(res, 200, { message: 'ok' });
+});
+
+const deleteComment = asyncTryCatch(async (req, res) => {
+  await commentService.remove(req.params.commentId);
+
+  responseHandler(res, 200, { message: 'ok' });
+});
+
+module.exports = { getComments, createComment, updateComment, deleteComment };

--- a/server/src/controllers/task.js
+++ b/server/src/controllers/task.js
@@ -9,6 +9,12 @@ const getTaskById = asyncTryCatch(async (req, res) => {
   responseHandler(res, 200, task);
 });
 
+const getAllTasks = asyncTryCatch(async (req, res) => {
+  const tasks = await taskService.retrieveAll(req.user.id);
+
+  responseHandler(res, 200, { tasks });
+});
+
 const createTask = asyncTryCatch(async (req, res) => {
   const { labelIdList, dueDate, ...rest } = req.body;
 
@@ -43,4 +49,4 @@ const deleteTask = asyncTryCatch(async (req, res) => {
   responseHandler(res, 200, { message: 'ok' });
 });
 
-module.exports = { getTaskById, createTask, updateTask, deleteTask };
+module.exports = { getTaskById, getAllTasks, createTask, updateTask, deleteTask };

--- a/server/src/controllers/task.js
+++ b/server/src/controllers/task.js
@@ -16,7 +16,7 @@ const getAllTasks = asyncTryCatch(async (req, res) => {
 });
 
 const createTask = asyncTryCatch(async (req, res) => {
-  const { labelIdList, dueDate, ...rest } = req.body;
+  const { dueDate } = req.body;
 
   // TODO middle ware로 빼내는게 좋을 것 같음
   if (!isValidDueDate(dueDate)) {
@@ -25,12 +25,12 @@ const createTask = asyncTryCatch(async (req, res) => {
     throw err;
   }
 
-  await taskService.create(labelIdList, dueDate, rest);
+  await taskService.create(req.body);
   responseHandler(res, 201, { message: 'ok' });
 });
 
 const updateTask = asyncTryCatch(async (req, res) => {
-  const { labelIdList, dueDate, ...rest } = req.body;
+  const { dueDate } = req.body;
 
   if (!isValidDueDate(dueDate)) {
     const err = new Error('유효하지 않은 dueDate');
@@ -40,7 +40,7 @@ const updateTask = asyncTryCatch(async (req, res) => {
 
   const { taskId } = req.params;
 
-  await taskService.update(labelIdList, dueDate, taskId, rest);
+  await taskService.update({ id: taskId, ...req.body });
   responseHandler(res, 200, { message: 'ok' });
 });
 

--- a/server/src/controllers/task.js
+++ b/server/src/controllers/task.js
@@ -1,4 +1,3 @@
-const { models } = require('@models');
 const taskService = require('@services/task');
 const { asyncTryCatch } = require('@utils/async-try-catch');
 const { responseHandler } = require('@utils/handler');
@@ -44,53 +43,4 @@ const deleteTask = asyncTryCatch(async (req, res) => {
   responseHandler(res, 200, { message: 'ok' });
 });
 
-const getComments = asyncTryCatch(async (req, res) => {
-  const task = await models.task.findByPk(req.params.taskId);
-  const comments = await task.getComments();
-
-  responseHandler(res, 200, comments);
-});
-
-const createComment = asyncTryCatch(async (req, res) => {
-  const { taskId } = req.params;
-  await models.comment.create({ ...req.body, taskId });
-
-  responseHandler(res, 201, {
-    message: 'ok',
-  });
-});
-
-const updateComment = asyncTryCatch(async (req, res) => {
-  await models.comment.update(req.body, {
-    where: {
-      id: req.params.commentId,
-    },
-  });
-
-  responseHandler(res, 200, {
-    message: 'ok',
-  });
-});
-
-const deleteComment = asyncTryCatch(async (req, res) => {
-  await models.comment.destroy({
-    where: {
-      id: req.params.commentId,
-    },
-  });
-
-  responseHandler(res, 200, {
-    message: 'ok',
-  });
-});
-
-module.exports = {
-  getTaskById,
-  createTask,
-  updateTask,
-  deleteTask,
-  getComments,
-  createComment,
-  updateComment,
-  deleteComment,
-};
+module.exports = { getTaskById, createTask, updateTask, deleteTask };

--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -1,25 +1,19 @@
 const { responseHandler } = require('@utils/handler');
 const { createJWT } = require('@utils/auth');
+const { asyncTryCatch } = require('@utils/async-try-catch');
 
-const naverLogin = (req, res, next) => {
+const naverLogin = asyncTryCatch(async (req, res) => {
   const { CLIENT_URL } = process.env;
-  try {
-    const { user } = req;
-    const token = createJWT(user);
-    res.header('Authentication', token);
-    res.status(200).redirect(`${CLIENT_URL}?token=${token}`);
-  } catch (err) {
-    next(err);
-  }
-};
+  const { user } = req;
+  const token = createJWT(user);
 
-const getOwnInfo = (req, res, next) => {
-  try {
-    const { user } = req;
-    responseHandler(res, 200, user);
-  } catch (err) {
-    next(err);
-  }
-};
+  res.header('Authentication', token);
+  res.status(200).redirect(`${CLIENT_URL}?token=${token}`);
+});
+
+const getOwnInfo = asyncTryCatch(async (req, res) => {
+  const { user } = req;
+  responseHandler(res, 200, user);
+});
 
 module.exports = { naverLogin, getOwnInfo };

--- a/server/src/models/seeders/index.js
+++ b/server/src/models/seeders/index.js
@@ -15,6 +15,14 @@ const users = [
     createdAt: new Date(),
     updatedAt: new Date(),
   },
+  {
+    id: '58719e77-5f55-4ca7-9552-ff94fbb07ea4',
+    email: 'dimple0416@naver.com',
+    name: '박진영',
+    provider: 'naver',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
 ];
 
 const priorities = [
@@ -63,6 +71,15 @@ const projects = [
     createdAt: new Date(),
     updatedAt: new Date(),
   },
+  {
+    id: '082b92fb-dce7-4249-9467-2f261767196b',
+    creatorId: users[2].id,
+    title: '내 프로젝트',
+    isList: false,
+    isFavorite: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
 ];
 
 const sections = [
@@ -78,6 +95,14 @@ const sections = [
     id: 'cccf0633-bce2-4972-9249-69f287db8a47',
     title: '섹션 2',
     projectId: projects[0].id,
+    position: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: 'dbfc6305-877e-46b9-ac63-d56fb82681dd',
+    title: '섹션 3',
+    projectId: projects[2].id,
     position: 1,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -161,6 +186,17 @@ const tasks = [
     sectionId: sections[1].id,
     title: '작업 7',
     dueDate: new Date('2021-10-24T14:23:24.090Z'),
+    position: 1,
+    isDone: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: '4a83b457-e67e-43d8-a284-78ea7fc440d5',
+    projectId: projects[2].id,
+    sectionId: sections[2].id,
+    title: '진영',
+    dueDate: new Date(),
     position: 1,
     isDone: false,
     createdAt: new Date(),

--- a/server/src/passport/naver-strategy.js
+++ b/server/src/passport/naver-strategy.js
@@ -1,6 +1,5 @@
 const NaverStrategy = require('passport-naver').Strategy;
-// const userService = require('@services/user');
-const userModel = require('@models').models.user;
+const userService = require('@services/user');
 
 const data = {
   clientID: process.env.NAVER_CLIENT_ID,
@@ -12,13 +11,7 @@ const getNaverUser = async (accessToken, refreshToken, profile, done) => {
   const NAVER = 'naver';
   try {
     const { email, nickname } = profile._json;
-
-    // let user = await userService.retrieveByEmail(email, NAVER);
-    const [user] = await userModel.findOrCreate({
-      where: { email, provider: NAVER },
-      attributes: ['id', 'email', 'name', 'provider'],
-      defaults: { email, name: nickname, provider: NAVER },
-    });
+    const [user] = await userService.retrieveOrCreate(email, nickname, NAVER);
 
     return done(null, user.toJSON());
   } catch (err) {

--- a/server/src/passport/naver-strategy.js
+++ b/server/src/passport/naver-strategy.js
@@ -11,7 +11,7 @@ const getNaverUser = async (accessToken, refreshToken, profile, done) => {
   const NAVER = 'naver';
   try {
     const { email, nickname } = profile._json;
-    const [user] = await userService.retrieveOrCreate(email, nickname, NAVER);
+    const [user] = await userService.retrieveOrCreate({ email, nickname, provider: NAVER });
 
     return done(null, user.toJSON());
   } catch (err) {

--- a/server/src/routes/index.js
+++ b/server/src/routes/index.js
@@ -4,9 +4,10 @@ const userRouter = require('@routes/user');
 const taskRouter = require('@routes/task');
 const projectRouter = require('@routes/project');
 const labelRouter = require('@routes/label');
+const { authenticateUser } = require('@utils/auth');
 
 router.use('/user', userRouter);
-router.use('/task', taskRouter);
+router.use('/task', authenticateUser, taskRouter);
 router.use('/project', projectRouter);
 router.use('/label', labelRouter);
 

--- a/server/src/routes/task.js
+++ b/server/src/routes/task.js
@@ -2,6 +2,7 @@ const router = require('express').Router();
 const taskController = require('@controllers/task');
 const commentController = require('@controllers/comment');
 
+// TODO validation check 로직 추가해야함
 router.get('/:taskId', taskController.getTaskById);
 router.post('/', taskController.createTask);
 router.patch('/:taskId', taskController.updateTask);

--- a/server/src/routes/task.js
+++ b/server/src/routes/task.js
@@ -3,8 +3,9 @@ const taskController = require('@controllers/task');
 const commentController = require('@controllers/comment');
 
 // TODO validation check 로직 추가해야함
-router.get('/:taskId', taskController.getTaskById);
+router.get('/', taskController.getAllTasks);
 router.post('/', taskController.createTask);
+router.get('/:taskId', taskController.getTaskById);
 router.patch('/:taskId', taskController.updateTask);
 router.delete('/:taskId', taskController.deleteTask);
 

--- a/server/src/routes/task.js
+++ b/server/src/routes/task.js
@@ -1,16 +1,15 @@
 const router = require('express').Router();
 const taskController = require('@controllers/task');
-const { authenticateUser } = require('@utils/auth');
+const commentController = require('@controllers/comment');
 
-// router.get('/', )
-router.get('/:taskId', authenticateUser, taskController.getTaskById);
-router.post('/', authenticateUser, taskController.createTask);
-router.patch('/:taskId', authenticateUser, taskController.updateTask);
-router.delete('/:taskId', authenticateUser, taskController.deleteTask);
+router.get('/:taskId', taskController.getTaskById);
+router.post('/', taskController.createTask);
+router.patch('/:taskId', taskController.updateTask);
+router.delete('/:taskId', taskController.deleteTask);
 
-router.get('/:taskId/comment', authenticateUser, taskController.getComments);
-router.post('/:taskId/comment', authenticateUser, taskController.createComment);
-router.put('/:taskId/comment/:commentId', authenticateUser, taskController.updateComment);
-router.delete('/:taskId/comment/:commentId', authenticateUser, taskController.deleteComment);
+router.get('/:taskId/comment', commentController.getComments);
+router.post('/:taskId/comment', commentController.createComment);
+router.put('/:taskId/comment/:commentId', commentController.updateComment);
+router.delete('/:taskId/comment/:commentId', commentController.deleteComment);
 
 module.exports = router;

--- a/server/src/routes/task.js
+++ b/server/src/routes/task.js
@@ -1,14 +1,16 @@
 const router = require('express').Router();
 const taskController = require('@controllers/task');
+const { authenticateUser } = require('@utils/auth');
 
-router.get('/:taskId', taskController.getTaskById);
-router.post('/', taskController.createTask);
-router.patch('/:taskId', taskController.updateTask);
-router.delete('/:taskId', taskController.deleteTask);
+// router.get('/', )
+router.get('/:taskId', authenticateUser, taskController.getTaskById);
+router.post('/', authenticateUser, taskController.createTask);
+router.patch('/:taskId', authenticateUser, taskController.updateTask);
+router.delete('/:taskId', authenticateUser, taskController.deleteTask);
 
-router.get('/:taskId/comment', taskController.getComments);
-router.post('/:taskId/comment', taskController.createComment);
-router.put('/:taskId/comment/:commentId', taskController.updateComment);
-router.delete('/:taskId/comment/:commentId', taskController.deleteComment);
+router.get('/:taskId/comment', authenticateUser, taskController.getComments);
+router.post('/:taskId/comment', authenticateUser, taskController.createComment);
+router.put('/:taskId/comment/:commentId', authenticateUser, taskController.updateComment);
+router.delete('/:taskId/comment/:commentId', authenticateUser, taskController.deleteComment);
 
 module.exports = router;

--- a/server/src/services/comment.js
+++ b/server/src/services/comment.js
@@ -1,0 +1,30 @@
+const taskModel = require('@models').models.task;
+const commentModel = require('@models').models.comment;
+
+const retrieveAllByTaskId = async taskId => {
+  const task = await taskModel.findByPk(taskId);
+  const comments = await task.getComments();
+
+  return comments;
+};
+
+const create = async (taskId, commentData) => {
+  const result = await commentModel.create({ ...commentData, taskId });
+
+  return result;
+};
+
+const update = async (id, data) => {
+  const result = await commentModel.update(data, { where: { id } });
+
+  return result;
+};
+
+const remove = async id => {
+  const result = await commentModel.destroy({
+    where: { id },
+  });
+  return result;
+};
+
+module.exports = { retrieveAllByTaskId, create, update, remove };

--- a/server/src/services/task.js
+++ b/server/src/services/task.js
@@ -1,0 +1,62 @@
+const taskModel = require('@models').models.task;
+const sequelize = require('@models');
+
+const retrieveById = async id => {
+  const task = await taskModel.findByPk(id, {
+    include: [
+      'labels',
+      'priority',
+      'alarm',
+      'bookmarks',
+      {
+        model: taskModel,
+        include: ['labels', 'priority', 'alarm', 'bookmarks'],
+      },
+    ],
+    order: [[taskModel, 'position', 'ASC']],
+  });
+  return task;
+};
+
+const create = async (labelIdList, dueDate, taskData) => {
+  const result = await sequelize.transaction(async t => {
+    const task = await taskModel.create({ dueDate, ...taskData }, { transaction: t });
+    await task.setLabels(JSON.parse(labelIdList), { transaction: t });
+
+    return task;
+  });
+
+  return !!result;
+};
+
+const update = async (labelIdList, dueDate, id, taskData) => {
+  const result = await sequelize.transaction(async t => {
+    await taskModel.update(
+      { dueDate, ...taskData },
+      {
+        where: { id },
+      },
+      { transaction: t },
+    );
+
+    const task = await taskModel.findByPk(id, { transaction: t });
+    if (labelIdList) {
+      await task.setLabels(JSON.parse(labelIdList), { transaction: t });
+    }
+    return true;
+  });
+
+  return result;
+};
+
+const remove = async id => {
+  const result = await taskModel.destroy({
+    where: {
+      id,
+    },
+  });
+
+  return result;
+};
+
+module.exports = { retrieveById, create, update, remove };

--- a/server/src/services/task.js
+++ b/server/src/services/task.js
@@ -1,5 +1,7 @@
-const taskModel = require('@models').models.task;
 const sequelize = require('@models');
+
+const { models } = sequelize;
+const taskModel = models.task;
 
 const retrieveById = async id => {
   const task = await taskModel.findByPk(id, {
@@ -16,6 +18,20 @@ const retrieveById = async id => {
     order: [[taskModel, 'position', 'ASC']],
   });
   return task;
+};
+
+const retrieveAll = async userId => {
+  const tasks = await taskModel.findAll({
+    attributes: ['id', 'title'],
+    include: {
+      model: models.project,
+      attributes: [],
+      where: { creatorId: userId },
+    },
+    // order: [['title', 'ASC']],
+  });
+
+  return tasks;
 };
 
 const create = async (labelIdList, dueDate, taskData) => {
@@ -59,4 +75,4 @@ const remove = async id => {
   return result;
 };
 
-module.exports = { retrieveById, create, update, remove };
+module.exports = { retrieveById, retrieveAll, create, update, remove };

--- a/server/src/services/task.js
+++ b/server/src/services/task.js
@@ -34,9 +34,10 @@ const retrieveAll = async userId => {
   return tasks;
 };
 
-const create = async (labelIdList, dueDate, taskData) => {
+const create = async taskData => {
+  const { labelIdList, dueDate, ...rest } = taskData;
   const result = await sequelize.transaction(async t => {
-    const task = await taskModel.create({ dueDate, ...taskData }, { transaction: t });
+    const task = await taskModel.create({ dueDate, ...rest }, { transaction: t });
     await task.setLabels(JSON.parse(labelIdList), { transaction: t });
 
     return task;
@@ -45,10 +46,11 @@ const create = async (labelIdList, dueDate, taskData) => {
   return !!result;
 };
 
-const update = async (labelIdList, dueDate, id, taskData) => {
+const update = async taskData => {
+  const { id, labelIdList, dueDate, ...rest } = taskData;
   const result = await sequelize.transaction(async t => {
     await taskModel.update(
-      { dueDate, ...taskData },
+      { dueDate, ...rest },
       {
         where: { id },
       },

--- a/server/src/services/user.js
+++ b/server/src/services/user.js
@@ -7,7 +7,8 @@ const retrieveById = async id => {
   return foundUser;
 };
 
-const retrieveOrCreate = async (email, name, provider) => {
+const retrieveOrCreate = async userData => {
+  const { email, name, provider } = userData;
   const user = await userModel.findOrCreate({
     where: { email, provider },
     attributes: ['id', 'email', 'name', 'provider'],

--- a/server/src/services/user.js
+++ b/server/src/services/user.js
@@ -1,0 +1,25 @@
+const userModel = require('@models').models.user;
+
+const retrieveById = async id => {
+  const foundUser = await userModel.findByPk(id, {
+    attributes: ['id', 'email', 'name', 'provider'],
+  });
+  return foundUser;
+};
+
+const retrieveOrCreate = async (email, name, provider) => {
+  const user = await userModel.findOrCreate({
+    where: { email, provider },
+    attributes: ['id', 'email', 'name', 'provider'],
+    defaults: { email, name, provider },
+  });
+
+  return user;
+};
+
+const register = async data => {
+  const result = await userModel.create(data);
+  return result;
+};
+
+module.exports = { retrieveById, retrieveOrCreate, register };

--- a/server/test/project.api.test.js
+++ b/server/test/project.api.test.js
@@ -18,11 +18,16 @@ const SUCCESS_MSG = 'ok';
 
 describe('get all projects', () => {
   it('project get all 일반', done => {
-    const expectedProjects = [
-      { id: 'b7f253e5-7b6b-4ee2-b94e-369ffcdffb5f', taskCount: 5, title: '프로젝트 1' },
-      { id: 'f7605077-96ec-4365-88fc-a9c3af4a084e', taskCount: 0, title: '프로젝트 2' },
-      { taskCount: 2, title: '오늘' },
-    ];
+    const expectedProjects = seeder.projects.map(project => {
+      const tasks = seeder.tasks.filter(task => task.projectId === project.id);
+      const { id, title } = project;
+      return { id, title, taskCount: tasks.length };
+    });
+    //  [
+    //   { id: 'b7f253e5-7b6b-4ee2-b94e-369ffcdffb5f', taskCount: 5, title: '프로젝트 1' },
+    //   { id: 'f7605077-96ec-4365-88fc-a9c3af4a084e', taskCount: 0, title: '프로젝트 2' },
+    //   { taskCount: 2, title: '오늘' },
+    // ];
 
     try {
       request(app)
@@ -31,8 +36,15 @@ describe('get all projects', () => {
           if (err) {
             throw err;
           }
+          expect(
+            res.body.every(project =>
+              expectedProjects.some(
+                expectedProject =>
+                  Object.entries(project).toString === Object.entries(expectedProject).toString,
+              ),
+            ),
+          ).toBeTruthy();
 
-          expect(res.body).toEqual(expectedProjects);
           done();
         });
     } catch (err) {

--- a/server/test/task.api.test.js
+++ b/server/test/task.api.test.js
@@ -23,7 +23,7 @@ describe('get All task', () => {
       // when
       const res = await request(app)
         .get('/api/task')
-        .set('Authorization', createJWT(seeder.users[0]));
+        .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`);
 
       const { tasks } = res.body;
       // then
@@ -42,7 +42,10 @@ describe('get task by id', () => {
 
     try {
       // when
-      const res = await request(app).get(`/api/task/${taskId}`);
+      const res = await request(app)
+        .get(`/api/task/${taskId}`)
+        .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`);
+
       const recievedChildren = res.body.tasks.filter(task => task.parentId === taskId);
 
       // then
@@ -74,7 +77,10 @@ describe('post task', () => {
     };
 
     // when
-    const res = await request(app).post('/api/task').send(newTask);
+    const res = await request(app)
+      .post('/api/task')
+      .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
+      .send(newTask);
 
     // then
     expect(res.status).toBe(status.SUCCESS.POST.CODE);
@@ -96,7 +102,10 @@ describe('post task', () => {
     };
 
     // when
-    const res = await request(app).post('/api/task').send(newTask);
+    const res = await request(app)
+      .post('/api/task')
+      .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
+      .send(newTask);
 
     // then
     expect(res.status).toBe(status.SUCCESS.POST.CODE);
@@ -118,7 +127,10 @@ describe('post task', () => {
     };
 
     // when
-    const res = await request(app).post('/api/task').send(newTask);
+    const res = await request(app)
+      .post('/api/task')
+      .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
+      .send(newTask);
 
     // then
     expect(res.status).toBe(status.SUCCESS.POST.CODE);
@@ -140,7 +152,10 @@ describe('post task', () => {
     };
 
     // when
-    const res = await request(app).post('/api/task').send(newTask);
+    const res = await request(app)
+      .post('/api/task')
+      .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
+      .send(newTask);
 
     // then
     expect(res.status).toBe(status.SUCCESS.POST.CODE);
@@ -162,7 +177,10 @@ describe('post task', () => {
     };
 
     // when
-    const res = await request(app).post('/api/task').send(newTask);
+    const res = await request(app)
+      .post('/api/task')
+      .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
+      .send(newTask);
 
     // then
     expect(res.status).toBe(status.SUCCESS.POST.CODE);
@@ -184,7 +202,10 @@ describe('post task', () => {
     };
 
     // when
-    const res = await request(app).post('/api/task').send(newTask);
+    const res = await request(app)
+      .post('/api/task')
+      .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
+      .send(newTask);
 
     // then
     expect(res.status).toBe(status.SUCCESS.POST.CODE);
@@ -206,7 +227,10 @@ describe('post task', () => {
     };
 
     // when
-    const res = await request(app).post('/api/task').send(newTask);
+    const res = await request(app)
+      .post('/api/task')
+      .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
+      .send(newTask);
 
     // then
     expect(res.status).toBe(status.BAD_REQUEST.CODE);
@@ -231,7 +255,10 @@ describe('patch task with id', () => {
 
     try {
       // when
-      const res = await request(app).patch(`/api/task/${seeder.tasks[1].id}`).send(newTask);
+      const res = await request(app)
+        .patch(`/api/task/${seeder.tasks[1].id}`)
+        .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
+        .send(newTask);
 
       // then
       expect(res.status).toBe(status.SUCCESS.CODE);
@@ -249,7 +276,9 @@ describe('delete task', () => {
     const taskId = seeder.tasks[0].id;
     try {
       // when
-      const res = await request(app).delete(`/api/task/${taskId}`);
+      const res = await request(app)
+        .delete(`/api/task/${taskId}`)
+        .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`);
 
       // then
       expect(res.status).toBe(status.SUCCESS.CODE);
@@ -269,7 +298,9 @@ describe('get comments', () => {
 
     try {
       // when
-      const res = await request(app).get(`/api/task/${taskId}/comment`);
+      const res = await request(app)
+        .get(`/api/task/${taskId}/comment`)
+        .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`);
       const firstCommentId = res.body[0].id;
 
       // then
@@ -291,7 +322,10 @@ describe('create comment', () => {
 
     try {
       // when
-      const res = await request(app).post(`/api/task/${taskId}/comment`).send(requestBody);
+      const res = await request(app)
+        .post(`/api/task/${taskId}/comment`)
+        .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
+        .send(requestBody);
 
       // then
       expect(res.status).toBe(status.SUCCESS.POST.CODE);
@@ -315,6 +349,7 @@ describe('update comment', () => {
       // when
       const res = await request(app)
         .put(`/api/task/${taskId}/comment/${commentId}`)
+        .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
         .send(requestBody);
 
       // then
@@ -340,6 +375,7 @@ describe('delete comment', () => {
       // when
       const res = await request(app)
         .delete(`/api/task/${taskId}/comment/${commentId}`)
+        .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
         .send(requestBody);
 
       // then

--- a/server/test/task.api.test.js
+++ b/server/test/task.api.test.js
@@ -268,6 +268,35 @@ describe('patch task with id', () => {
       done(err);
     }
   });
+
+  it('patch task without labels', async done => {
+    // given
+    const newTask = {
+      title: '할일',
+      projectId: seeder.projects[0].id,
+      labelIdList: JSON.stringify([]),
+      priorityId: seeder.priorities[0].id,
+      dueDate: new Date(),
+      parentId: null,
+      alarmId: seeder.alarms[0].id,
+      position: 1,
+    };
+
+    try {
+      // when
+      const res = await request(app)
+        .patch(`/api/task/${seeder.tasks[2].id}`)
+        .set('Authorization', `Bearer ${createJWT(seeder.users[0])}`)
+        .send(newTask);
+
+      // then
+      expect(res.status).toBe(status.SUCCESS.CODE);
+      expect(res.body.message).toBe(status.SUCCESS.MSG);
+      done();
+    } catch (err) {
+      done(err);
+    }
+  });
 });
 
 describe('delete task', () => {

--- a/server/test/task.api.test.js
+++ b/server/test/task.api.test.js
@@ -2,7 +2,8 @@ require('module-alias/register');
 const request = require('supertest');
 const app = require('@root/app');
 const seeder = require('@test/test-seed');
-const { projects, tasks, labels, priorities, alarms } = require('@test/test-seed');
+const status = require('@test/response-status');
+const { createJWT } = require('@utils/auth');
 
 beforeAll(async done => {
   await seeder.up();
@@ -14,25 +15,44 @@ afterAll(async done => {
   done();
 });
 
-const SUCCESS_CODE = 201;
-const SUCCESS_MSG = 'ok';
+describe('get All task', () => {
+  it('성공 조건', async done => {
+    // given
+    const expectedTasks = [];
+    try {
+      // when
+      const res = await request(app)
+        .get('/api/task')
+        .set('Authorization', createJWT(seeder.users[0]));
+
+      const { tasks } = res.body;
+      // then
+      expect(tasks).toStrictEqual(expectedTasks);
+    } catch (err) {
+      done(err);
+    }
+  });
+});
 
 describe('get task by id', () => {
-  it('get task by id 일반', done => {
-    const expectedChildTaskId = '8d62f93c-9233-46a9-a5cf-ec18ad5a36f4';
+  it('get task by id 일반', async done => {
+    // given
+    const taskId = seeder.tasks[0].id;
+    const expectedChildren = seeder.tasks.filter(task => task.parentId === taskId);
 
     try {
-      request(app)
-        .get('/api/task/13502adf-83dd-4e8e-9acf-5c5a0abd5b1b')
-        .end((err, res) => {
-          if (err) {
-            throw err;
-          }
+      // when
+      const res = await request(app).get(`/api/task/${taskId}`);
+      const recievedChildren = res.body.tasks.filter(task => task.parentId === taskId);
 
-          const firstChildTaskId = res.body.tasks[0].id;
-          expect(firstChildTaskId).toEqual(expectedChildTaskId);
-          done();
-        });
+      // then
+      recievedChildren.forEach(recievedChild => {
+        expect(
+          expectedChildren.some(expectedChild => recievedChild.id === expectedChild.id),
+        ).toBeTruthy();
+      });
+
+      done();
     } catch (err) {
       done(err);
     }
@@ -44,18 +64,21 @@ describe('post task', () => {
     // given
     const newTask = {
       title: '할일',
-      projectId: projects[0].id,
-      labelIdList: JSON.stringify(labels.map(label => label.id)),
-      priorityId: priorities[0].id,
-      dueDate: '2021-11-28',
+      projectId: seeder.projects[0].id,
+      labelIdList: JSON.stringify(seeder.labels.map(label => label.id)),
+      priorityId: seeder.priorities[0].id,
+      dueDate: new Date(),
       parentId: null,
-      alarmId: alarms[0].id,
+      alarmId: seeder.alarms[0].id,
       position: 1,
     };
 
+    // when
     const res = await request(app).post('/api/task').send(newTask);
-    expect(res.status).toBe(201);
-    expect(res.body.message).toBe('ok');
+
+    // then
+    expect(res.status).toBe(status.SUCCESS.POST.CODE);
+    expect(res.body.message).toBe(status.SUCCESS.MSG);
     done();
   });
 
@@ -64,18 +87,20 @@ describe('post task', () => {
     const newTask = {
       title: '할일',
       projectId: null,
-      labelIdList: JSON.stringify(labels.map(label => label.id)),
-      priorityId: priorities[0].id,
-      dueDate: '2020-11-28',
+      labelIdList: JSON.stringify(seeder.labels.map(label => label.id)),
+      priorityId: seeder.priorities[0].id,
+      dueDate: new Date(),
       parentId: null,
-      alarmId: alarms[0].id,
+      alarmId: seeder.alarms[0].id,
       position: 1,
     };
 
+    // when
     const res = await request(app).post('/api/task').send(newTask);
 
-    expect(res.status).toBe(201);
-    expect(res.body.message).toBe('ok');
+    // then
+    expect(res.status).toBe(status.SUCCESS.POST.CODE);
+    expect(res.body.message).toBe(status.SUCCESS.MSG);
     done();
   });
 
@@ -83,19 +108,21 @@ describe('post task', () => {
     // given
     const newTask = {
       title: '할일',
-      projectId: projects[0].id,
+      projectId: seeder.projects[0].id,
       labelIdList: JSON.stringify([]),
-      priorityId: priorities[1].id,
-      dueDate: '2020-11-28',
+      priorityId: seeder.priorities[1].id,
+      dueDate: new Date(),
       parentId: null,
-      alarmId: alarms[0].id,
+      alarmId: seeder.alarms[0].id,
       position: 1,
     };
 
+    // when
     const res = await request(app).post('/api/task').send(newTask);
 
-    expect(res.status).toBe(201);
-    expect(res.body.message).toBe('ok');
+    // then
+    expect(res.status).toBe(status.SUCCESS.POST.CODE);
+    expect(res.body.message).toBe(status.SUCCESS.MSG);
     done();
   });
 
@@ -103,19 +130,21 @@ describe('post task', () => {
     // given
     const newTask = {
       title: '할일',
-      projectId: projects[0].id,
+      projectId: seeder.projects[0].id,
       labelIdList: JSON.stringify([]),
       priorityId: null,
-      dueDate: '2020-11-28',
+      dueDate: new Date(),
       parentId: null,
-      alarmId: alarms[0].id,
+      alarmId: seeder.alarms[0].id,
       position: 1,
     };
 
+    // when
     const res = await request(app).post('/api/task').send(newTask);
 
-    expect(res.status).toBe(201);
-    expect(res.body.message).toBe('ok');
+    // then
+    expect(res.status).toBe(status.SUCCESS.POST.CODE);
+    expect(res.body.message).toBe(status.SUCCESS.MSG);
     done();
   });
 
@@ -123,19 +152,21 @@ describe('post task', () => {
     // given
     const newTask = {
       title: '할일',
-      projectId: projects[1].id,
+      projectId: seeder.projects[1].id,
       labelIdList: JSON.stringify([]),
-      priorityId: priorities[1].id,
-      dueDate: '2020-11-28',
-      parentId: tasks[0].id,
-      alarmId: alarms[0].id,
+      priorityId: seeder.priorities[1].id,
+      dueDate: new Date(),
+      parentId: seeder.tasks[0].id,
+      alarmId: seeder.alarms[0].id,
       position: 1,
     };
 
+    // when
     const res = await request(app).post('/api/task').send(newTask);
 
-    expect(res.status).toBe(201);
-    expect(res.body.message).toBe('ok');
+    // then
+    expect(res.status).toBe(status.SUCCESS.POST.CODE);
+    expect(res.body.message).toBe(status.SUCCESS.MSG);
     done();
   });
 
@@ -143,19 +174,21 @@ describe('post task', () => {
     // given
     const newTask = {
       title: '할일',
-      projectId: projects[1].id,
+      projectId: seeder.projects[1].id,
       labelIdList: JSON.stringify([]),
-      priorityId: priorities[1].id,
-      dueDate: '2020-11-28',
-      parentId: tasks[0].id,
+      priorityId: seeder.priorities[1].id,
+      dueDate: new Date(),
+      parentId: seeder.tasks[0].id,
       alarmId: null,
       position: 1,
     };
 
+    // when
     const res = await request(app).post('/api/task').send(newTask);
 
-    expect(res.status).toBe(201);
-    expect(res.body.message).toBe('ok');
+    // then
+    expect(res.status).toBe(status.SUCCESS.POST.CODE);
+    expect(res.body.message).toBe(status.SUCCESS.MSG);
     done();
   });
 
@@ -163,48 +196,47 @@ describe('post task', () => {
     // given
     const newTask = {
       title: '할일',
-      projectId: projects[1].id,
+      projectId: seeder.projects[1].id,
       labelIdList: JSON.stringify([]),
-      priorityId: priorities[1].id,
+      priorityId: seeder.priorities[1].id,
       dueDate: '2020-10-28',
-      parentId: tasks[0].id,
+      parentId: seeder.tasks[0].id,
       alarmId: null,
       position: 1,
     };
 
+    // when
     const res = await request(app).post('/api/task').send(newTask);
 
-    expect(res.status).toBe(400);
+    // then
+    expect(res.status).toBe(status.BAD_REQUEST.CODE);
     expect(res.body.message).toBe('유효하지 않은 dueDate');
     done();
   });
 });
 
-describe('post task with id (업데이트)', () => {
-  it('post task with id 일반', done => {
+describe('patch task with id', () => {
+  it('patch task with id 일반', async done => {
+    // given
     const newTask = {
       title: '할일',
-      projectId: projects[0].id,
-      labelIdList: JSON.stringify(labels.map(label => label.id)),
-      priorityId: priorities[0].id,
-      dueDate: '2021-11-28',
+      projectId: seeder.projects[0].id,
+      labelIdList: JSON.stringify(seeder.labels.map(label => label.id)),
+      priorityId: seeder.priorities[0].id,
+      dueDate: new Date(),
       parentId: null,
-      alarmId: alarms[0].id,
+      alarmId: seeder.alarms[0].id,
       position: 1,
     };
 
     try {
-      request(app)
-        .post('/api/task/13502adf-83dd-4e8e-9acf-5c5a0abd5b1b')
-        .send(newTask)
-        .end((err, res) => {
-          if (err) {
-            throw err;
-          }
-          expect(res.status).toBe(201);
-          expect(res.body.message).toBe('ok');
-          done();
-        });
+      // when
+      const res = await request(app).patch(`/api/task/${seeder.tasks[1].id}`).send(newTask);
+
+      // then
+      expect(res.status).toBe(status.SUCCESS.CODE);
+      expect(res.body.message).toBe(status.SUCCESS.MSG);
+      done();
     } catch (err) {
       done(err);
     }
@@ -212,18 +244,17 @@ describe('post task with id (업데이트)', () => {
 });
 
 describe('delete task', () => {
-  it('delete task 일반', done => {
+  it('delete task 일반', async done => {
+    // given
+    const taskId = seeder.tasks[0].id;
     try {
-      request(app)
-        .delete('/api/task/13502adf-83dd-4e8e-9acf-5c5a0abd5b1b')
-        .end((err, res) => {
-          if (err) {
-            throw err;
-          }
-          expect(res.status).toBe(201);
-          expect(res.body.message).toBe('ok');
-          done();
-        });
+      // when
+      const res = await request(app).delete(`/api/task/${taskId}`);
+
+      // then
+      expect(res.status).toBe(status.SUCCESS.CODE);
+      expect(res.body.message).toBe(status.SUCCESS.MSG);
+      done();
     } catch (err) {
       done(err);
     }
@@ -231,21 +262,19 @@ describe('delete task', () => {
 });
 
 describe('get comments', () => {
-  it('get comments 일반', done => {
-    const expectedCommentId = '6200bcb9-f871-439b-9507-57abbde3d468';
+  it('get comments 일반', async done => {
+    // given
+    const expectedCommentId = seeder.comments[0].id;
+    const taskId = seeder.tasks[1].id;
 
     try {
-      request(app)
-        .get('/api/task/cd62f93c-9233-46a9-a5cf-ec18ad5a36f4/comment')
-        .end((err, res) => {
-          if (err) {
-            throw err;
-          }
+      // when
+      const res = await request(app).get(`/api/task/${taskId}/comment`);
+      const firstCommentId = res.body[0].id;
 
-          const firstCommentId = res.body[0].id;
-          expect(firstCommentId).toEqual(expectedCommentId);
-          done();
-        });
+      // then
+      expect(firstCommentId).toEqual(expectedCommentId);
+      done();
     } catch (err) {
       done(err);
     }
@@ -253,23 +282,21 @@ describe('get comments', () => {
 });
 
 describe('create comment', () => {
-  it('create comment 일반', done => {
+  it('create comment 일반', async done => {
+    // given
     const requestBody = {
       content: '새로운 댓글',
     };
+    const taskId = seeder.tasks[1].id;
 
     try {
-      request(app)
-        .post('/api/task/cd62f93c-9233-46a9-a5cf-ec18ad5a36f4/comment')
-        .send(requestBody)
-        .end((err, res) => {
-          if (err) {
-            throw err;
-          }
-          expect(res.status).toBe(SUCCESS_CODE);
-          expect(res.body.message).toBe(SUCCESS_MSG);
-          done();
-        });
+      // when
+      const res = await request(app).post(`/api/task/${taskId}/comment`).send(requestBody);
+
+      // then
+      expect(res.status).toBe(status.SUCCESS.POST.CODE);
+      expect(res.body.message).toBe(status.SUCCESS.MSG);
+      done();
     } catch (err) {
       done(err);
     }
@@ -277,25 +304,23 @@ describe('create comment', () => {
 });
 
 describe('update comment', () => {
-  it('update comment 일반', done => {
+  it('update comment 일반', async done => {
+    // given
     const requestBody = {
       content: '바뀐 댓글',
     };
-
+    const taskId = seeder.tasks[1].id;
+    const commentId = seeder.comments[0].id;
     try {
-      request(app)
-        .put(
-          '/api/task/cd62f93c-9233-46a9-a5cf-ec18ad5a36f4/comment/6200bcb9-f871-439b-9507-57abbde3d468',
-        )
-        .send(requestBody)
-        .end((err, res) => {
-          if (err) {
-            throw err;
-          }
-          expect(res.status).toBe(SUCCESS_CODE);
-          expect(res.body.message).toBe(SUCCESS_MSG);
-          done();
-        });
+      // when
+      const res = await request(app)
+        .put(`/api/task/${taskId}/comment/${commentId}`)
+        .send(requestBody);
+
+      // then
+      expect(res.status).toBe(status.SUCCESS.CODE);
+      expect(res.body.message).toBe(status.SUCCESS.MSG);
+      done();
     } catch (err) {
       done(err);
     }
@@ -303,25 +328,24 @@ describe('update comment', () => {
 });
 
 describe('delete comment', () => {
-  it('delete comment 일반', done => {
+  it('delete comment 일반', async done => {
+    // given
     const requestBody = {
       content: '바뀐 댓글',
     };
+    const taskId = seeder.tasks[1].id;
+    const commentId = seeder.comments[0].id;
 
     try {
-      request(app)
-        .delete(
-          '/api/task/cd62f93c-9233-46a9-a5cf-ec18ad5a36f4/comment/6200bcb9-f871-439b-9507-57abbde3d468',
-        )
-        .send(requestBody)
-        .end((err, res) => {
-          if (err) {
-            throw err;
-          }
-          expect(res.status).toBe(SUCCESS_CODE);
-          expect(res.body.message).toBe(SUCCESS_MSG);
-          done();
-        });
+      // when
+      const res = await request(app)
+        .delete(`/api/task/${taskId}/comment/${commentId}`)
+        .send(requestBody);
+
+      // then
+      expect(res.status).toBe(status.SUCCESS.CODE);
+      expect(res.body.message).toBe(status.SUCCESS.MSG);
+      done();
     } catch (err) {
       done(err);
     }

--- a/server/test/test-seed.js
+++ b/server/test/test-seed.js
@@ -57,7 +57,7 @@ const priorities = [
 const projects = [
   {
     id: 'b7f253e5-7b6b-4ee2-b94e-369ffcdffb5f',
-    creatorId: 'ff4dd832-1567-4d74-b41d-bd85e96ce329',
+    creatorId: users[0].id,
     title: '프로젝트 1',
     isList: true,
     isFavorite: false,
@@ -66,8 +66,17 @@ const projects = [
   },
   {
     id: 'f7605077-96ec-4365-88fc-a9c3af4a084e',
-    creatorId: users[1].id,
+    creatorId: users[0].id,
     title: '프로젝트 2',
+    isList: false,
+    isFavorite: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: 'ed298270-fc55-45d7-bc41-bb63ffd09b4a',
+    creatorId: users[1].id,
+    title: '프로젝트 3',
     isList: false,
     isFavorite: true,
     createdAt: new Date(),
@@ -85,6 +94,12 @@ const sections = [
   {
     id: 'efd8be46-ebc7-438d-931a-036a4b28789f',
     projectId: projects[1].id,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: 'cd57769e-7227-44da-bf6c-60f1a49ff6e3',
+    projectId: projects[2].id,
     createdAt: new Date(),
     updatedAt: new Date(),
   },
@@ -152,8 +167,8 @@ const tasks = [
   },
   {
     id: '568d0233-0e6e-4ff2-bdae-4c492e55f111',
-    projectId: projects[1].id,
-    sectionId: sections[1].id,
+    projectId: projects[2].id,
+    sectionId: sections[2].id,
     parentId: null,
     title: '작업 6',
     dueDate: new Date(),

--- a/server/test/test-seed.js
+++ b/server/test/test-seed.js
@@ -17,6 +17,14 @@ const users = [
     createdAt: new Date(),
     updatedAt: new Date(),
   },
+  {
+    id: 'c83abea3-bc93-44a4-b56c-dda6c742a94d',
+    email: 'kyle@naver.com',
+    name: 'kyle',
+    provider: 'naver',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
 ];
 
 const priorities = [
@@ -58,7 +66,7 @@ const projects = [
   },
   {
     id: 'f7605077-96ec-4365-88fc-a9c3af4a084e',
-    creatorId: 'ff4dd832-1567-4d74-b41d-bd85e96ce329',
+    creatorId: users[1].id,
     title: '프로젝트 2',
     isList: false,
     isFavorite: true,
@@ -71,6 +79,12 @@ const sections = [
   {
     id: '7abf0633-bce2-4972-9249-69f287db8a47',
     projectId: projects[0].id,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: 'efd8be46-ebc7-438d-931a-036a4b28789f',
+    projectId: projects[1].id,
     createdAt: new Date(),
     updatedAt: new Date(),
   },
@@ -131,6 +145,18 @@ const tasks = [
     parentId: '13502adf-83dd-4e8e-9acf-5c5a0abd5b1b',
     title: '작업 5',
     dueDate: new Date('2020-10-24T14:23:24.090Z'),
+    position: 1,
+    isDone: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: '568d0233-0e6e-4ff2-bdae-4c492e55f111',
+    projectId: projects[1].id,
+    sectionId: sections[1].id,
+    parentId: null,
+    title: '작업 6',
+    dueDate: new Date(),
     position: 1,
     isDone: false,
     createdAt: new Date(),


### PR DESCRIPTION
### 작업내용
#### FE
1. front api 요청 파일에서 /api 주소가 빠진 부분 수정
2. 전체 task 검색 api 추가
3. Home에서 Header 컴포넌트 분기처리
4. Header 컴포넌트와 Search 컴포넌트 분기처리
5. 검색 컴포넌트 구현


---
#### BE


1. task test 코드 상태 값 및 하드 코딩 수정, API 요청 결과를 async & await으로 변경
2. task controller & service 로직 분기 처리
3. task & comment 로직 분리 및 comment controller & service 분기 처리
4. user controller & service 로직 분기 처리
5. passport에서 user model에 접근하던 로직을 service 접근으로 수정
6. 사용자 인증 미들웨어를 index에서 적용시키는 것으로 쉉

### 코멘트
- service 로직을 분기하고, comment 책임도 분기하면서 task controller가 지니던 책임이 무거웠다고 느꼈습니다.
   - 이번 경험을 토대로 확장성을 고려한 개발에 대해 그 이유가 더욱 명확해졌습니다.
- test 코드를 수정하는데 어려움을 겪었습니다. 
   - 테스트 코드 또한 의존성을 없애는 것이 중요하다고 다시 한번 느꼈습니다.
- front와 back 두 가지 사항을 한번에 pr 날리게되어 죄송합니다.. 다음부터는 하나씩만 올릴 수 있도록 branch 작업을 더 신경쓰겠습니다..

### 이슈번호
#124  #114 