### PR TITLE
작업 상세 화면 작업 & router 수정

### DIFF
--- a/client/src/components/project/ProjectContainer.vue
+++ b/client/src/components/project/ProjectContainer.vue
@@ -32,7 +32,7 @@
       </v-list-item>
 
       <div v-for="(task, index) in section.tasks" :key="task.id" class="task-container">
-        <task-item @pop="showTaskModal(task.id)" :section="section" :task="task" :position="index" />
+        <task-item :section="section" :task="task" :position="index" />
 
         <v-divider />
 
@@ -43,18 +43,14 @@
 
       <add-task :projectId="section.projectId" :sectionId="section.id" />
     </v-list>
-    <v-dialog v-model="dialog" max-width="290" @click:outside="hideTaskModal()">
-      <router-view />
-    </v-dialog>
   </div>
 </template>
 
 <script>
-import { mapGetters, mapActions } from "vuex";
+import { mapActions } from "vuex";
 import AddTask from "@/components/project/AddTask";
 import TaskItem from "@/components/project/TaskItem";
 import UpdatableTitle from "@/components/common/UpdatableTitle";
-import router from "@/router";
 
 export default {
   props: {
@@ -62,21 +58,11 @@ export default {
   },
   data() {
     return {
-      dialog: !!this.$route.params.taskId,
       projectId: this.$route.params.projectId,
     };
   },
   methods: {
     ...mapActions(["updateTaskToDone"]),
-    showTaskModal(taskId) {
-      this.dialog = true;
-      router
-        .push({ name: "TaskDetail", params: { taskId, projectId: this.projectId } })
-        .catch(() => {});
-    },
-    hideTaskModal() {
-      router.push(`/project/${this.projectId}`);
-    },   
   },
   components: { AddTask, TaskItem, UpdatableTitle },
 };
@@ -92,5 +78,11 @@ export default {
 .project-container {
   width: 100%;
   max-width: 600px;
+}
+
+.v-dialog {
+  max-width: 80%;
+  min-height: 80%;
+  background-color: white;
 }
 </style>

--- a/client/src/components/project/TaskItem.vue
+++ b/client/src/components/project/TaskItem.vue
@@ -18,11 +18,12 @@
       </v-radio-group>
     </v-list-item-action>
 
-    <div class="task-div" @click="showModal()">
+    <div class="task-div" @click="moveToTaskDetail()">
       <v-list-item-content>
         <v-list-item-title>{{ task.title }}</v-list-item-title>
       </v-list-item-content>
     </div>
+    <router-view />
   </v-list-item>
 </template>
 
@@ -30,10 +31,10 @@
 import { mapGetters, mapActions } from "vuex";
 
 export default {
-  props: { 
-      task: Object, 
-      section: Object, 
-      position: Number  
+  props: {
+    task: Object,
+    section: Object,
+    position: Number,
   },
   data() {
     return {
@@ -43,8 +44,15 @@ export default {
   },
   methods: {
     ...mapActions(["updateTaskToDone", "startDragTask", "changeTaskPosition"]),
-    showModal() {
-      this.$emit("pop");
+
+    moveToTaskDetail() {
+      console.log(this.task);
+      this.$router
+        .push({
+          name: "TaskDetail",
+          params: { projectId: this.task.projectId, taskId: this.task.id },
+        })
+        .catch(() => {});
     },
     handleDragStart() {
       this.dragging = true;
@@ -117,5 +125,5 @@ export default {
   background-color: #1c2b82;
   color: white;
   padding-left: 10px;
- }
+}
 </style>

--- a/client/src/components/project/TaskItem.vue
+++ b/client/src/components/project/TaskItem.vue
@@ -46,13 +46,14 @@ export default {
     ...mapActions(["updateTaskToDone", "startDragTask", "changeTaskPosition"]),
 
     moveToTaskDetail() {
-      console.log(this.task);
-      this.$router
-        .push({
-          name: "TaskDetail",
-          params: { projectId: this.task.projectId, taskId: this.task.id },
-        })
-        .catch(() => {});
+      const destinationInfo = this.$route.params.projectId
+        ? {
+            name: "ProjectTaskDetail",
+            params: { projectId: this.task.projectId, taskId: this.task.id },
+          }
+        : { name: "TodayTaskDetail", params: { taskId: this.task.id } };
+
+      this.$router.push(destinationInfo).catch(() => {});
     },
     handleDragStart() {
       this.dragging = true;

--- a/client/src/components/task/TaskDetail.vue
+++ b/client/src/components/task/TaskDetail.vue
@@ -1,10 +1,19 @@
 <template>
-  <div>{{ currentTask }} hi!!</div>
-  <!-- <div>{{ currentTask }}}</div> -->
+  <v-dialog v-model="dialog" @click:outside="hideTaskModal()">
+    <v-flex>
+      <v-list-item>
+        <v-list-item-group>
+          <v-list-item-title> </v-list-item-title>
+          <div>{{ currentTask }} hi!!</div>
+        </v-list-item-group>
+      </v-list-item>
+    </v-flex>
+  </v-dialog>
 </template>
 
 <script>
 import { mapGetters, mapActions } from "vuex";
+import UpdatableTitle from "@/components/common/UpdatableTitle";
 
 export default {
   data() {
@@ -16,10 +25,16 @@ export default {
 
   methods: {
     ...mapActions(["fetchCurrentTask"]),
+    hideTaskModal() {
+      this.$router.go(-1);
+    },
   },
   computed: mapGetters(["currentTask"]),
   created() {
     this.fetchCurrentTask(this.$route.params.taskId);
+  },
+  components: {
+    UpdatableTitle,
   },
 };
 </script>

--- a/client/src/components/task/TaskDetail.vue
+++ b/client/src/components/task/TaskDetail.vue
@@ -1,42 +1,41 @@
 <template>
-  <v-dialog v-model="dialog" @click:outside="hideTaskModal()">
-    <v-flex>
-      <v-list-item>
-        <v-list-item-group>
-          <v-list-item-title> </v-list-item-title>
-          <div>{{ currentTask }} hi!!</div>
-        </v-list-item-group>
-      </v-list-item>
-    </v-flex>
-  </v-dialog>
+  <!-- <v-dialog v-model="dialog" :retain-focus="false" @click:outside="hideTaskModal()"> -->
+  <v-flex>
+    <v-list-item class="flex-column">
+      <v-list-item-group class="d-flex">
+        <v-list-item-title>
+          <div class="task_detail-project_title">{{ projectTitle }}</div>
+        </v-list-item-title>
+        <v-btn icon @click="hideTaskModal()">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </v-list-item-group>
+      <div>{{ task }} hi!!</div>
+    </v-list-item>
+  </v-flex>
+  <!-- </v-dialog> -->
 </template>
 
 <script>
-import { mapGetters, mapActions } from "vuex";
-import UpdatableTitle from "@/components/common/UpdatableTitle";
-
 export default {
-  data() {
-    return {
-      dialog: true,
-      taskId: this.$route.params.taskId,
-    };
+  props: {
+    task: Object,
+    projectTitle: String,
   },
 
   methods: {
-    ...mapActions(["fetchCurrentTask"]),
     hideTaskModal() {
-      this.$router.go(-1);
+      this.$emit("hideTaskModal");
     },
   },
-  computed: mapGetters(["currentTask"]),
-  created() {
-    this.fetchCurrentTask(this.$route.params.taskId);
-  },
-  components: {
-    UpdatableTitle,
-  },
+  computed: {},
+  created() {},
+  mounted() {},
 };
 </script>
 
-<style></style>
+<style>
+.v-list-item {
+  align-items: initial;
+}
+</style>

--- a/client/src/components/today/TodayTasksContainer.vue
+++ b/client/src/components/today/TodayTasksContainer.vue
@@ -4,9 +4,7 @@
       <v-list-item class="font-weight-black text-h6"> 기한이 지난 </v-list-item>
 
       <div v-for="task in expiredTasks" :key="task.id" class="task-container">
-        <div @click="popTaskDetail(task)">
-          <task-item :task="task" />
-        </div>
+        <task-item :task="task" />
 
         <v-divider />
 
@@ -21,9 +19,7 @@
       <v-list-item class="font-weight-black text-h6"> 오늘 </v-list-item>
 
       <div v-for="task in todayTasks" :key="task.id" class="task-container">
-        <div @click="popTaskDetail(task)">
-          <task-item :task="task" />
-        </div>
+        <task-item :task="task" />
 
         <v-divider />
 
@@ -52,10 +48,6 @@ export default {
   },
   methods: {
     ...mapActions(["updateTaskToDone"]),
-    popTaskDetail(task) {
-      this.$router.push(`/task/${task.id}`);
-      // router.push(`/task/${obj.id}`).catch(() => {});
-    },
   },
   components: { TaskItem },
 };

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -46,6 +46,13 @@ const routes = [
         name: "Today",
         component: Today,
         beforeEnter: requireAuth(),
+        children: [
+          {
+            path: "task/:taskId",
+            name: "TodayTaskDetail",
+            component: TaskDetail,
+          },
+        ],
       },
       {
         path: "project/:projectId",
@@ -55,7 +62,7 @@ const routes = [
         children: [
           {
             path: "task/:taskId",
-            name: "TaskDetail",
+            name: "ProjectTaskDetail",
             component: TaskDetail,
           },
         ],

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -6,7 +6,7 @@ import Project from "@/views/Project.vue";
 import Task from "@/views/Task.vue";
 import Home from "@/views/Home.vue";
 import userAPI from "@/api/user";
-import TaskDetail from "@/components/task/TaskDetail.vue";
+// import TaskDetail from "@/components/task/TaskDetail.vue";
 
 Vue.use(VueRouter);
 
@@ -50,7 +50,7 @@ const routes = [
           {
             path: "task/:taskId",
             name: "TodayTaskDetail",
-            component: TaskDetail,
+            component: Task,
           },
         ],
       },
@@ -63,7 +63,7 @@ const routes = [
           {
             path: "task/:taskId",
             name: "ProjectTaskDetail",
-            component: TaskDetail,
+            component: Task,
           },
         ],
       },

--- a/client/src/views/Project.vue
+++ b/client/src/views/Project.vue
@@ -4,7 +4,7 @@
 
 <script>
 import { mapGetters, mapActions } from "vuex";
-import ProjectContainer from "../components/project/ProjectContainer";
+import ProjectContainer from "@/components/project/ProjectContainer";
 
 export default {
   components: { ProjectContainer },
@@ -15,8 +15,10 @@ export default {
   created() {
     this.fetchCurrentProject(this.$route.params.projectId);
   },
+
   beforeRouteUpdate(to, from, next) {
     this.fetchCurrentProject(to.params.projectId);
+    next();
   },
 };
 </script>

--- a/client/src/views/Task.vue
+++ b/client/src/views/Task.vue
@@ -3,7 +3,7 @@
     <task-detail
       @hideTaskModal="hideTaskModal"
       :task="currentTask"
-      :projectTitle="getProjectTitle"
+      :projectTitle="projectTitle"
     ></task-detail>
   </v-dialog>
 </template>
@@ -29,22 +29,13 @@ export default {
   },
   computed: {
     ...mapGetters(["currentTask", "namedProjectInfos"]),
-    getProjectTitle() {
-      return this.namedProjectInfos.find((project) => project.id === this.currentTask.projectId)
-        .title;
-    },
   },
 
-  created() {
-    // console.log(this);
-    this.fetchCurrentTask(this.$route.params.taskId);
+  async created() {
+    await this.fetchCurrentTask(this.$route.params.taskId);
+    this.projectTitle = this.namedProjectInfos.find(
+      (project) => project.id === this.currentTask.projectId
+    ).title;
   },
-  // mounted() {
-  //   this.projectTitle = this.getProjectTitle();
-  // },
-  // beforeRouteUpdate(to, from, next) {
-  //   this.fetchCurrentTask(to.params.taskId);
-  //   next();
-  // },
 };
 </script>

--- a/client/src/views/Task.vue
+++ b/client/src/views/Task.vue
@@ -1,11 +1,50 @@
 <template>
-  <div>
-    <div>Task View</div>
-  </div>
+  <v-dialog v-model="dialog" :retain-focus="false" @click:outside="hideTaskModal()">
+    <task-detail
+      @hideTaskModal="hideTaskModal"
+      :task="currentTask"
+      :projectTitle="getProjectTitle"
+    ></task-detail>
+  </v-dialog>
 </template>
 
 <script>
+import { mapGetters, mapActions } from "vuex";
+import TaskDetail from "@/components/task/TaskDetail.vue";
+
 export default {
   name: "Task",
+  data() {
+    return {
+      dialog: true,
+      projectTitle: "무제",
+    };
+  },
+  components: { TaskDetail },
+  methods: {
+    ...mapActions(["fetchCurrentTask"]),
+    hideTaskModal() {
+      this.$router.go(-1);
+    },
+  },
+  computed: {
+    ...mapGetters(["currentTask", "namedProjectInfos"]),
+    getProjectTitle() {
+      return this.namedProjectInfos.find((project) => project.id === this.currentTask.projectId)
+        .title;
+    },
+  },
+
+  created() {
+    // console.log(this);
+    this.fetchCurrentTask(this.$route.params.taskId);
+  },
+  // mounted() {
+  //   this.projectTitle = this.getProjectTitle();
+  // },
+  // beforeRouteUpdate(to, from, next) {
+  //   this.fetchCurrentTask(to.params.taskId);
+  //   next();
+  // },
 };
 </script>


### PR DESCRIPTION
### 작업내용
- [x] Today에서 작업을 클릭하면 Today/task/:taskId로 라우터가 변하면서 모달창이 뜬다.
- [x] Project에서 작업을 클릭하면 route가 /project/:projectId/task/:taskId로 바뀌면서 모달 창이 뜬다.
- [x] 모달 창에 프로젝트 이름과 task 정보가 나타난다.
- [x] X 버튼 혹은 blur된 영역을 클릭하면 모달이 사라지면서 이전 라우터로 돌아간다.
- [x] task 상세 화면으로 직접 주소를 쳐서 들어와도 모달창이 보이고, 모달 종료시 project url로 바뀌며 화면이 보인다.

### 코멘트
- TaskDetail을 Task 컴포넌트의 하위 컴포넌트로 변경했습니다.
- 이에 따라 router에 설정된 컴포넌트를 Task 컴포넌트로 대체하면서, Today와 Project 하위에서 모두 라우터가 이동하게 설정했습니다.
- Vue의 Life Cycle을 이해하는데 오랜 시간이 걸렸습니다.. $nextTick과 mounted를 이용해보려고 했지만, 두 메소드 모두 Task 컴포넌트를 구현하는데 부적합하다고 판단했습니다.
- 데이터가 생성되는 created 시점에 async & await을 걸어두어 현재 조회 중인 task의 데이터를 받아온 다음, project store의 namedProjectInfos를 받아와 id에 맞는 title을 반환해줬습니다.

### 이슈번호
#107 