### PR TITLE
디자인 수정 및 데모용 임시 처리

### DIFF
--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
@@ -16,7 +16,7 @@ class MenuViewController: UIViewController {
                         Project(color: "#B2CCFF", title: "To Do", taskNum: 8),
                         Project(color: "#B7F0B1", title: "할고래두 프로젝트🐳", taskNum: 12),
                         Project(color: "#FFE08C", title: "네이버 웨일 프젝", taskNum: 3),
-                        Project(color: "#FFA7A7", title: "카카오 코테⭐️", taskNum: 10)]
+                        Project(color: "#FFA7A7", title: "네이버 코테⭐️", taskNum: 10)]
     
     struct Project: Hashable {
         private let identifier = UUID()
@@ -57,7 +57,11 @@ class MenuViewController: UIViewController {
         configureCollectionView()
         configureDataSource()
         applyInitialSnapshots()
-      //performSegue(withIdentifier: "MenuViewControllerTo TaskListViewController", sender: nil) //개발 선택 사항(첫번째 뷰 선택)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        title = "할고래DO"
     }
     
     // MARK: - Initialize
@@ -209,6 +213,14 @@ extension MenuViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         collectionView.deselectItem(at: indexPath, animated: true)
+        
+        let project = dataSource.snapshot().itemIdentifiers[indexPath.item+1]
+        guard let vc = storyboard?.instantiateViewController(identifier: "\(TaskListViewController.self)", creator: { (coder) -> TaskListViewController? in
+            return TaskListViewController(coder: coder)
+        }) else { return }
+        vc.title = project.title
+        vc.projectTitle = project.title ?? ""
+        navigationController?.pushViewController(vc, animated: true)
     }
 }
 

--- a/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskBoardViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskBoardViewController.swift
@@ -38,7 +38,13 @@ class TaskBoardViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        navigationController?.navigationBar.prefersLargeTitles = false
         interactor?.fetchTasks(request: .init())
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.navigationBar.prefersLargeTitles = true
     }
     
     // MARK: - Initialize

--- a/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskListRouter.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskListRouter.swift
@@ -48,6 +48,7 @@ extension TaskListRouter: TaskListRoutingLogic {
         else {
             return
         }
+        
         navigateToTaskDetail(source: sourceVC, destination: destinationVC)
     }
     

--- a/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskListViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskListViewController.swift
@@ -16,7 +16,7 @@ class TaskListViewController: UIViewController {
     // MARK: - Properties
     
     /// 임시 property
-    private var projectTitle = "할고래DO"
+    var projectTitle = "할고래DO"
     private var interactor: TaskListBusinessLogic?
     private var router: (TaskListRoutingLogic & TaskListDataPassing)?
     private var dataSource: UICollectionViewDiffableDataSource<String, TaskVM>! = nil
@@ -41,6 +41,7 @@ class TaskListViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        title = projectTitle
         configureLogic()
         configureCollectionView()
         configureDataSource()
@@ -114,6 +115,7 @@ class TaskListViewController: UIViewController {
                 return
             }
             
+            vc.title = self.projectTitle
             let nav = self.navigationController
             nav?.popViewController(animated: false)
             nav?.pushViewController(vc, animated: false)

--- a/iOS/HalgoraeDO/Sources/Scenes/TaskList/Views/TaskSectionViewCell.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/TaskList/Views/TaskSectionViewCell.swift
@@ -235,7 +235,7 @@ extension TaskSectionViewCell: UICollectionViewDropDelegate {
     ) {
         lineView.removeFromSuperview()
         #if DEBUG
-        print("destination path:", coordinator.destinationIndexPath)
+        print("destination path:", coordinator.destinationIndexPath ?? "Not found")
         #endif
     }
     
@@ -246,13 +246,13 @@ private extension TaskSectionViewCell {
     func setLocation(_ location: CGPoint, _ destination: IndexPath?) {
         #if DEBUG
         print("location:", location)
-        print("start:", startPoint)
+        print("start:", startPoint ?? "Not found")
         #endif
         
         lineView.removeFromSuperview()
         guard let destination = destination,
               let startIndex = startIndex,
-              let startPoint = startPoint,
+              let _ = startPoint,
               let collectionView = collectionView
         else {
             return

--- a/iOS/HalgoraeDO/Sources/Utils/UIColor+.swift
+++ b/iOS/HalgoraeDO/Sources/Utils/UIColor+.swift
@@ -20,16 +20,16 @@ extension UIColor {
 
 extension UIColor {
     
-    convenience init(hexFromString:String, alpha:CGFloat = 1.0) {
+    convenience init(hexFromString: String, alpha: CGFloat = 1.0) {
         var cString:String = hexFromString.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-        var rgbValue:UInt32 = 10066329 //color #999999 if string has wrong format
+        var rgbValue: UInt64 = 10066329 //color #999999 if string has wrong format
 
         if (cString.hasPrefix("#")) {
             cString.remove(at: cString.startIndex)
         }
 
         if ((cString.count) == 6) {
-            Scanner(string: cString).scanHexInt32(&rgbValue)
+            Scanner(string: cString).scanHexInt64(&rgbValue)
         }
 
         self.init(

--- a/iOS/HalgoraeDO/Sources/Views/Base.lproj/Main.storyboard
+++ b/iOS/HalgoraeDO/Sources/Views/Base.lproj/Main.storyboard
@@ -6,7 +6,6 @@
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
-        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -19,23 +18,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="yTg-6t-2Gl">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="nM7-5B-9zL">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="YmF-dx-NAf">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="whH-D6-tRf">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </collectionViewCellContentView>
-                                    </collectionViewCell>
-                                </cells>
+                                <cells/>
                             </collectionView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6wh-Eb-4oT" customClass="RoundButton" customModule="HalgoraeDO" customModuleProvider="target">
                                 <rect key="frame" x="350" y="798" width="44" height="44"/>
@@ -416,7 +406,7 @@
             </objects>
             <point key="canvasLocation" x="3830" y="798"/>
         </scene>
-        <!--할고래DO-->
+        <!--Task Board View Controller-->
         <scene sceneID="Yu7-Kn-tle">
             <objects>
                 <viewController storyboardIdentifier="TaskBoardViewController" id="U6H-lf-q4a" customClass="TaskBoardViewController" customModule="HalgoraeDO" customModuleProvider="target" sceneMemberID="viewController">
@@ -433,16 +423,7 @@
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="jcC-MV-Ekf">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="L77-zt-wdh">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </collectionViewCellContentView>
-                                    </collectionViewCell>
-                                </cells>
+                                <cells/>
                             </collectionView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vr2-Wc-fgQ"/>
@@ -454,7 +435,7 @@
                             <constraint firstItem="yK6-dz-zBK" firstAttribute="leading" secondItem="vr2-Wc-fgQ" secondAttribute="leading" id="i53-du-w3D"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="할고래DO" id="98D-Jg-aJM">
+                    <navigationItem key="navigationItem" id="98D-Jg-aJM">
                         <barButtonItem key="rightBarButtonItem" image="ellipsis" catalog="system" id="Wkv-8H-Efw">
                             <connections>
                                 <action selector="didTapMoreButton:" destination="U6H-lf-q4a" id="sCz-X7-TuZ"/>
@@ -474,8 +455,8 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="pcJ-NH-hpV" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="GJv-W2-k95">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="GJv-W2-k95">
+                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" red="0.1019607843" green="0.15218839049999999" blue="0.41057401900000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="barTintColor" red="0.029415823519999999" green="0.77209502460000001" blue="0.64217513800000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -551,7 +532,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="i1l-sl-RpB">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="140" width="414" height="722"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="2nZ-4X-snI">
                                     <size key="itemSize" width="128" height="128"/>
@@ -559,16 +540,7 @@
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="SyQ-et-RWE">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="F7Y-MW-fso">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </collectionViewCellContentView>
-                                    </collectionViewCell>
-                                </cells>
+                                <cells/>
                             </collectionView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="qIh-dh-kCn"/>
@@ -584,18 +556,7 @@
                             <constraint firstItem="qIh-dh-kCn" firstAttribute="bottom" secondItem="i1l-sl-RpB" secondAttribute="bottom" id="yHP-dr-uKZ"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="QCA-8H-c9B">
-                        <barButtonItem key="rightBarButtonItem" style="plain" id="A30-82-h5G">
-                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="uJ9-T2-H3k">
-                                <rect key="frame" x="316" y="7" width="78" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="임시이동버튼"/>
-                                <connections>
-                                    <segue destination="BYZ-38-t0r" kind="show" identifier="MenuViewControllerTo TaskListViewController" id="wzC-qO-rhL"/>
-                                </connections>
-                            </button>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" id="QCA-8H-c9B"/>
                     <connections>
                         <outlet property="menuCollectionView" destination="i1l-sl-RpB" id="SnW-CE-hhg"/>
                     </connections>

--- a/iOS/HalgoraeDO/Sources/Views/DatePickerButtonView/DatePickerButtonView.xib
+++ b/iOS/HalgoraeDO/Sources/Views/DatePickerButtonView/DatePickerButtonView.xib
@@ -20,16 +20,19 @@
             <rect key="frame" x="0.0" y="0.0" width="276" height="199"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="800" verticalCompressionResistancePriority="755" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yNM-kt-DqB">
-                    <rect key="frame" x="8" y="0.0" width="260" height="199"/>
+                <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" horizontalCompressionResistancePriority="800" verticalCompressionResistancePriority="755" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yNM-kt-DqB">
+                    <rect key="frame" x="8" y="0.0" width="155" height="199"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="155" id="rhY-Zf-j8g"/>
+                    </constraints>
                     <color key="tintColor" name="halgoraedoDarkBlue"/>
                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
                     <state key="normal" title="2020년" image="calendar" catalog="system">
                         <color key="titleColor" name="halgoraedoDarkBlue"/>
                     </state>
                 </button>
-                <datePicker opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="55J-Lv-lhK">
-                    <rect key="frame" x="8" y="0.0" width="260" height="199"/>
+                <datePicker opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="300" horizontalCompressionResistancePriority="800" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="55J-Lv-lhK">
+                    <rect key="frame" x="8" y="0.0" width="155" height="199"/>
                     <connections>
                         <action selector="valueChangedDatePicker:" destination="-1" eventType="valueChanged" id="x5D-M0-YPJ"/>
                     </connections>


### PR DESCRIPTION
### 구현 화면
<img src="https://user-images.githubusercontent.com/23303023/101112984-cc0a9b80-3621-11eb-9434-d6ceefa8d023.gif" width="30%" />

### 구현 내용
1. 멘토님께 피듭드백 받은 대로 애플스러운 느낌이 덜 들어서 네비게이션 타이틀을 수정했습니다.
2. 데모를 위해 프로젝트로 넘어가는 부분을 타이틀만 넘겨서 임시로 처리해뒀습니다.

### 코멘트
- 목록 화면에서 하단 + 플로팅 버튼을 툴바로 수정해야 합니다.
- 단순 타이틀이 아닌 의미있는 데이터를 주고받도록 수정해야 합니다.