### PR TITLE
메뉴 API 연동 및 즐겨찾기 개선

### DIFF
--- a/iOS/HalgoraeDO.xcodeproj/project.pbxproj
+++ b/iOS/HalgoraeDO.xcodeproj/project.pbxproj
@@ -77,6 +77,10 @@
 		4CE9157A257D0E5F00BCF398 /* SessionManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE91579257D0E5F00BCF398 /* SessionManagerMock.swift */; };
 		4CE9157F257D14CB00BCF398 /* CodableMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE9157E257D14CB00BCF398 /* CodableMock.swift */; };
 		4CE91584257D190900BCF398 /* DataRequestMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE91583257D190900BCF398 /* DataRequestMock.swift */; };
+		4CE915EB257F61DA00BCF398 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE915EA257F61DA00BCF398 /* Project.swift */; };
+		4CE915F0257F633200BCF398 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE915EF257F633200BCF398 /* Section.swift */; };
+		4CE915F5257F661E00BCF398 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE915F4257F661E00BCF398 /* Comment.swift */; };
+		4CE915FA257F662800BCF398 /* Bookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE915F9257F662800BCF398 /* Bookmark.swift */; };
 		AA19EF172575680600E59017 /* TaskSectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA19EF162575680500E59017 /* TaskSectionViewCell.swift */; };
 		AA19EF1B25756C3200E59017 /* AddSectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA19EF1A25756C3200E59017 /* AddSectionViewCell.swift */; };
 		AA19EF252576488B00E59017 /* TaskBoardSupplementaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA19EF242576488B00E59017 /* TaskBoardSupplementaryView.swift */; };
@@ -166,6 +170,10 @@
 		4CE91597257D315800BCF398 /* HalgoraeDO.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HalgoraeDO.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CE91598257D315800BCF398 /* TaskListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = TaskListTests.xctest; path = "/Users/os/woong/iOS/Boostcamp2020/group_final/Project04-C-Whale/iOS/build/Debug-iphoneos/TaskListTests.xctest"; sourceTree = "<absolute>"; };
 		4CE91599257D315800BCF398 /* ServiceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = ServiceTests.xctest; path = "/Users/os/woong/iOS/Boostcamp2020/group_final/Project04-C-Whale/iOS/build/Debug-iphoneos/ServiceTests.xctest"; sourceTree = "<absolute>"; };
+		4CE915EA257F61DA00BCF398 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
+		4CE915EF257F633200BCF398 /* Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
+		4CE915F4257F661E00BCF398 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
+		4CE915F9257F662800BCF398 /* Bookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bookmark.swift; sourceTree = "<group>"; };
 		AA19EF162575680500E59017 /* TaskSectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskSectionViewCell.swift; sourceTree = "<group>"; };
 		AA19EF1A25756C3200E59017 /* AddSectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSectionViewCell.swift; sourceTree = "<group>"; };
 		AA19EF242576488B00E59017 /* TaskBoardSupplementaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskBoardSupplementaryView.swift; sourceTree = "<group>"; };
@@ -262,9 +270,13 @@
 		4C3F5693256BA21B006D7C9F /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				4C3F5694256BA228006D7C9F /* Task.swift */,
 				4CCD3256256F8BA700A46D10 /* Priority.swift */,
 				4C4236B02573B4C90068A252 /* Priority+PopoverViewModelType.swift */,
+				4CE915EA257F61DA00BCF398 /* Project.swift */,
+				4CE915EF257F633200BCF398 /* Section.swift */,
+				4C3F5694256BA228006D7C9F /* Task.swift */,
+				4CE915F4257F661E00BCF398 /* Comment.swift */,
+				4CE915F9257F662800BCF398 /* Bookmark.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -648,6 +660,7 @@
 				AA19EF172575680600E59017 /* TaskSectionViewCell.swift in Sources */,
 				4C42371F25763B100068A252 /* TaskDetailWorker.swift in Sources */,
 				4C42370D25762FC10068A252 /* TaskDetailCommentViewController.swift in Sources */,
+				4CE915F0257F633200BCF398 /* Section.swift in Sources */,
 				4C3F573F256D2263006D7C9F /* RoundButton.swift in Sources */,
 				4C4236F825761A8E0068A252 /* TaskDetailPageViewController.swift in Sources */,
 				4C42370425761CB00068A252 /* TaskDetailSubTasksViewController.swift in Sources */,
@@ -656,6 +669,7 @@
 				AA19EF252576488B00E59017 /* TaskBoardSupplementaryView.swift in Sources */,
 				4C3F5695256BA228006D7C9F /* Task.swift in Sources */,
 				4C4236C32574C5F50068A252 /* TaskList.swift in Sources */,
+				4CE915F5257F661E00BCF398 /* Comment.swift in Sources */,
 				4C4236E02574DF980068A252 /* ConfirmActionView.swift in Sources */,
 				4C3F5705256CF8B9006D7C9F /* TaskContentView.swift in Sources */,
 				AA19EF332576846100E59017 /* UIColor+.swift in Sources */,
@@ -663,7 +677,9 @@
 				4C42386E257917790068A252 /* NetworkManager.swift in Sources */,
 				4CCD32772570A4EF00A46D10 /* MenuViewController.swift in Sources */,
 				4C4238A2257A2D800068A252 /* URLParameterEncoder.swift in Sources */,
+				4CE915C1257E1D5700BCF398 /* ProjectEndPoint.swift in Sources */,
 				4C0CA636256EAC5200E66045 /* TaskListDisplayLogic.swift in Sources */,
+				4CE915EB257F61DA00BCF398 /* Project.swift in Sources */,
 				4C4238602578D70D0068A252 /* EndPointType.swift in Sources */,
 				4C423751257792690068A252 /* BorderRadiusButton.swift in Sources */,
 				4C42372325763B1C0068A252 /* TaskDetailPresenter.swift in Sources */,
@@ -677,6 +693,7 @@
 				4C4238742579358A0068A252 /* DataRequest.swift in Sources */,
 				AA19EF1B25756C3200E59017 /* AddSectionViewCell.swift in Sources */,
 				4C42371B25763B080068A252 /* TaskDetailInteractor.swift in Sources */,
+				4CE915FA257F662800BCF398 /* Bookmark.swift in Sources */,
 				4C423896257A2A560068A252 /* ParameterEncoding.swift in Sources */,
 				4C42387A25794C8C0068A252 /* SessionManager.swift in Sources */,
 				4C42374125771BA40068A252 /* DatePickerButtonView.swift in Sources */,

--- a/iOS/HalgoraeDO.xcodeproj/project.pbxproj
+++ b/iOS/HalgoraeDO.xcodeproj/project.pbxproj
@@ -77,10 +77,16 @@
 		4CE9157A257D0E5F00BCF398 /* SessionManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE91579257D0E5F00BCF398 /* SessionManagerMock.swift */; };
 		4CE9157F257D14CB00BCF398 /* CodableMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE9157E257D14CB00BCF398 /* CodableMock.swift */; };
 		4CE91584257D190900BCF398 /* DataRequestMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE91583257D190900BCF398 /* DataRequestMock.swift */; };
+		4CE915C1257E1D5700BCF398 /* ProjectEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE915C0257E1D5700BCF398 /* ProjectEndPoint.swift */; };
 		4CE915EB257F61DA00BCF398 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE915EA257F61DA00BCF398 /* Project.swift */; };
 		4CE915F0257F633200BCF398 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE915EF257F633200BCF398 /* Section.swift */; };
 		4CE915F5257F661E00BCF398 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE915F4257F661E00BCF398 /* Comment.swift */; };
 		4CE915FA257F662800BCF398 /* Bookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE915F9257F662800BCF398 /* Bookmark.swift */; };
+		4CE91605257F81B600BCF398 /* MenuInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE91604257F81B600BCF398 /* MenuInteractor.swift */; };
+		4CE9160A257F81BD00BCF398 /* MenuWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE91609257F81BD00BCF398 /* MenuWorker.swift */; };
+		4CE9160F257F81C500BCF398 /* MenuPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE9160E257F81C500BCF398 /* MenuPresenter.swift */; };
+		4CE91614257F82A100BCF398 /* MenuModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE91613257F82A100BCF398 /* MenuModels.swift */; };
+		4CE91619257F83AD00BCF398 /* MenuRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE91618257F83AD00BCF398 /* MenuRouter.swift */; };
 		AA19EF172575680600E59017 /* TaskSectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA19EF162575680500E59017 /* TaskSectionViewCell.swift */; };
 		AA19EF1B25756C3200E59017 /* AddSectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA19EF1A25756C3200E59017 /* AddSectionViewCell.swift */; };
 		AA19EF252576488B00E59017 /* TaskBoardSupplementaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA19EF242576488B00E59017 /* TaskBoardSupplementaryView.swift */; };
@@ -170,10 +176,16 @@
 		4CE91597257D315800BCF398 /* HalgoraeDO.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HalgoraeDO.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CE91598257D315800BCF398 /* TaskListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = TaskListTests.xctest; path = "/Users/os/woong/iOS/Boostcamp2020/group_final/Project04-C-Whale/iOS/build/Debug-iphoneos/TaskListTests.xctest"; sourceTree = "<absolute>"; };
 		4CE91599257D315800BCF398 /* ServiceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = ServiceTests.xctest; path = "/Users/os/woong/iOS/Boostcamp2020/group_final/Project04-C-Whale/iOS/build/Debug-iphoneos/ServiceTests.xctest"; sourceTree = "<absolute>"; };
+		4CE915C0257E1D5700BCF398 /* ProjectEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectEndPoint.swift; sourceTree = "<group>"; };
 		4CE915EA257F61DA00BCF398 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
 		4CE915EF257F633200BCF398 /* Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
 		4CE915F4257F661E00BCF398 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		4CE915F9257F662800BCF398 /* Bookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bookmark.swift; sourceTree = "<group>"; };
+		4CE91604257F81B600BCF398 /* MenuInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuInteractor.swift; sourceTree = "<group>"; };
+		4CE91609257F81BD00BCF398 /* MenuWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuWorker.swift; sourceTree = "<group>"; };
+		4CE9160E257F81C500BCF398 /* MenuPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuPresenter.swift; sourceTree = "<group>"; };
+		4CE91613257F82A100BCF398 /* MenuModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuModels.swift; sourceTree = "<group>"; };
+		4CE91618257F83AD00BCF398 /* MenuRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRouter.swift; sourceTree = "<group>"; };
 		AA19EF162575680500E59017 /* TaskSectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskSectionViewCell.swift; sourceTree = "<group>"; };
 		AA19EF1A25756C3200E59017 /* AddSectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSectionViewCell.swift; sourceTree = "<group>"; };
 		AA19EF242576488B00E59017 /* TaskBoardSupplementaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskBoardSupplementaryView.swift; sourceTree = "<group>"; };
@@ -325,6 +337,7 @@
 		4C42385E2578D6FD0068A252 /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				4CE915B7257E1B7F00BCF398 /* EndPoints */,
 				4C423894257A2A450068A252 /* Encoding */,
 				4C42385F2578D70D0068A252 /* EndPointType.swift */,
 				4C42386D257917790068A252 /* NetworkManager.swift */,
@@ -388,6 +401,11 @@
 			isa = PBXGroup;
 			children = (
 				4CCD32762570A4EF00A46D10 /* MenuViewController.swift */,
+				4CE91604257F81B600BCF398 /* MenuInteractor.swift */,
+				4CE91609257F81BD00BCF398 /* MenuWorker.swift */,
+				4CE9160E257F81C500BCF398 /* MenuPresenter.swift */,
+				4CE91613257F82A100BCF398 /* MenuModels.swift */,
+				4CE91618257F83AD00BCF398 /* MenuRouter.swift */,
 			);
 			path = Menu;
 			sourceTree = "<group>";
@@ -415,6 +433,7 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
+				4CE915C0257E1D5700BCF398 /* ProjectEndPoint.swift */,
 		AAEE20D12564E4A900668FAD = {
 			isa = PBXGroup;
 			children = (
@@ -658,9 +677,11 @@
 				4CCD324E256F84BD00A46D10 /* PopoverViewModelType.swift in Sources */,
 				4C3F5679256B8C83006D7C9F /* TaskListPresenter.swift in Sources */,
 				AA19EF172575680600E59017 /* TaskSectionViewCell.swift in Sources */,
+				4CE91605257F81B600BCF398 /* MenuInteractor.swift in Sources */,
 				4C42371F25763B100068A252 /* TaskDetailWorker.swift in Sources */,
 				4C42370D25762FC10068A252 /* TaskDetailCommentViewController.swift in Sources */,
 				4CE915F0257F633200BCF398 /* Section.swift in Sources */,
+				4CE9160A257F81BD00BCF398 /* MenuWorker.swift in Sources */,
 				4C3F573F256D2263006D7C9F /* RoundButton.swift in Sources */,
 				4C4236F825761A8E0068A252 /* TaskDetailPageViewController.swift in Sources */,
 				4C42370425761CB00068A252 /* TaskDetailSubTasksViewController.swift in Sources */,
@@ -686,16 +707,19 @@
 				4C4236B12573B4C90068A252 /* Priority+PopoverViewModelType.swift in Sources */,
 				AAEE20E02564E4A900668FAD /* SceneDelegate.swift in Sources */,
 				4C3F5683256B8F4B006D7C9F /* TaskListRouter.swift in Sources */,
+				4CE9160F257F81C500BCF398 /* MenuPresenter.swift in Sources */,
 				4C3F566A256B82F2006D7C9F /* TaskBoardViewController.swift in Sources */,
 				4C3F5665256B8117006D7C9F /* TaskListViewController.swift in Sources */,
 				4CCD325E256F8C1200A46D10 /* UIImage+scaled.swift in Sources */,
 				4C3F5700256CF8A7006D7C9F /* TaskContentConfigure.swift in Sources */,
+				4CE91614257F82A100BCF398 /* MenuModels.swift in Sources */,
 				4C4238742579358A0068A252 /* DataRequest.swift in Sources */,
 				AA19EF1B25756C3200E59017 /* AddSectionViewCell.swift in Sources */,
 				4C42371B25763B080068A252 /* TaskDetailInteractor.swift in Sources */,
 				4CE915FA257F662800BCF398 /* Bookmark.swift in Sources */,
 				4C423896257A2A560068A252 /* ParameterEncoding.swift in Sources */,
 				4C42387A25794C8C0068A252 /* SessionManager.swift in Sources */,
+				4CE91619257F83AD00BCF398 /* MenuRouter.swift in Sources */,
 				4C42374125771BA40068A252 /* DatePickerButtonView.swift in Sources */,
 				4C4236FE25761AA00068A252 /* TaskDetailViewController.swift in Sources */,
 				4C3F5674256B8C63006D7C9F /* TaskListWorker.swift in Sources */,

--- a/iOS/HalgoraeDO.xcodeproj/xcshareddata/xcschemes/HalgoraeDO.xcscheme
+++ b/iOS/HalgoraeDO.xcodeproj/xcshareddata/xcschemes/HalgoraeDO.xcscheme
@@ -101,6 +101,13 @@
             ReferencedContainer = "container:HalgoraeDO.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "token"
+            value = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjM1NzNjYmJlLWJiYmItNDFhMy1hMzJkLWY4MTE4YjE1YTJiZCIsImVtYWlsIjoiY2N3MTAyMS5kZXZAZ21haWwuY29tIiwibmFtZSI6Iuy1nOyyoOybhSIsInByb3ZpZGVyIjoibmF2ZXIiLCJpYXQiOjE2MDczMjkwNjYsImV4cCI6MTYwNzMzMjY2Nn0.yDbVfkgRCaht6iAM0GUwYniKX8QX5NeIukMIxqbbhG4&quot;"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/iOS/HalgoraeDO/Sources/Models/Bookmark.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Bookmark.swift
@@ -1,0 +1,13 @@
+//
+//  Bookmark.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/12/08.
+//
+
+import Foundation
+
+struct Bookmark: Codable {
+    var id: UUID
+    var url: String
+}

--- a/iOS/HalgoraeDO/Sources/Models/Bookmark.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Bookmark.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct Bookmark: Codable {
-    var id: UUID
+    var id: String
     var url: String
 }

--- a/iOS/HalgoraeDO/Sources/Models/Comment.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Comment.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct Comment: Codable {
-    var id: UUID
+    var id: String
     var contents: String
 }

--- a/iOS/HalgoraeDO/Sources/Models/Comment.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Comment.swift
@@ -1,0 +1,13 @@
+//
+//  Comment.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/12/08.
+//
+
+import Foundation
+
+struct Comment: Codable {
+    var id: UUID
+    var contents: String
+}

--- a/iOS/HalgoraeDO/Sources/Models/Priority.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Priority.swift
@@ -18,3 +18,7 @@ enum Priority: Int, CaseIterable {
         return "우선순위 \(self.rawValue)"
     }
 }
+
+extension Priority: Codable {
+    
+}

--- a/iOS/HalgoraeDO/Sources/Models/Project.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Project.swift
@@ -14,6 +14,20 @@ class Project: Codable {
     var isFavorite: Bool?
     var isList: Bool?
     var sections: [Section]?
+    
+    init(id: String? = UUID().uuidString,
+         title: String,
+         taskCount: Int = 0,
+         isFavorite: Bool? = false,
+         isList: Bool? = false,
+         sections: [Section]? = []) {
+        self.id = id
+        self.title = title
+        self.taskCount = taskCount
+        self.isFavorite = isFavorite
+        self.isList = isList
+        self.sections = sections
+    }
 }
 
 extension Project: Hashable {

--- a/iOS/HalgoraeDO/Sources/Models/Project.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Project.swift
@@ -1,0 +1,16 @@
+//
+//  Project.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/12/08.
+//
+
+import Foundation
+
+class Project: Codable {
+    var id: UUID
+    var title: String
+    var taskCount: Int
+    var isList: Bool
+    var sections: [Section]
+}

--- a/iOS/HalgoraeDO/Sources/Models/Project.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Project.swift
@@ -8,9 +8,20 @@
 import Foundation
 
 class Project: Codable {
-    var id: UUID
+    var id: String?
     var title: String
     var taskCount: Int
-    var isList: Bool
-    var sections: [Section]
+    var isFavorite: Bool?
+    var isList: Bool?
+    var sections: [Section]?
+}
+
+extension Project: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+    
+    static func ==(lhs: Project, rhs: Project) -> Bool {
+        return lhs.id == rhs.id
+    }
 }

--- a/iOS/HalgoraeDO/Sources/Models/Section.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Section.swift
@@ -1,0 +1,16 @@
+//
+//  Section.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/12/08.
+//
+
+import Foundation
+
+class Section: Codable {
+    var id: UUID
+    var title: String
+    var createdAt: Date
+    var updatedAt: Date
+    var tasks: [Task]
+}

--- a/iOS/HalgoraeDO/Sources/Models/Section.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Section.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class Section: Codable {
-    var id: UUID
+    var id: String
     var title: String
     var createdAt: Date
     var updatedAt: Date

--- a/iOS/HalgoraeDO/Sources/Models/Task.swift
+++ b/iOS/HalgoraeDO/Sources/Models/Task.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-class Task {
+final class Task {
 
     // MARK:  - Constatns
     
-    let identifier = UUID()
+    let id: String = UUID().uuidString
     
     // MARK: - Properties
     
@@ -19,26 +19,39 @@ class Task {
     weak var parent: Task?
     var section: String
     var title: String
-    var isCompleted: Bool
+    var isDone: Bool
     var dueDate: Date
-    var priority: Priority
+    var createdAt: Date
+    var updatedAt: Date
+    var priority: Priority?
+    var comments: [Comment]
+    var bookmarks: [Bookmark]
     
     init(section: String = "",
          title: String,
          isCompleted: Bool = false,
          dueDate: Date = Date(),
+         createdAt: Date = Date(),
+         updatedAt: Date = Date(),
          priority: Priority = .four,
          parent: Task? = nil,
-         subTasks: [Task] = []) {
+         subTasks: [Task] = [],
+         comments: [Comment] = [],
+         bookmarks: [Bookmark] = []
+    ) {
         
         self.section = section
         self.title = title
-        self.isCompleted = isCompleted
+        self.isDone = isCompleted
         self.dueDate = dueDate
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
         self.priority = priority
         self.parent = parent
         self.subTasks = subTasks
-        self.subTasks.forEach { $0.parent = self }
+        // self.subTasks.forEach { $0.parent = self }
+        self.comments = comments
+        self.bookmarks = bookmarks
     }
         
     // MARK: - Methods
@@ -64,15 +77,19 @@ class Task {
     }
 }
 
+extension Task: Codable {
+    
+}
+
 // MARK: - Hashable
 
 extension Task: Hashable {
     func hash(into hasher: inout Hasher) {
-        hasher.combine(identifier)
+        hasher.combine(id)
     }
     
     static func ==(lhs: Task, rhs: Task) -> Bool {
-        return lhs.identifier == rhs.identifier
+        return lhs.id == rhs.id
     }
 }
 
@@ -80,6 +97,6 @@ extension Task: Hashable {
 
 extension Task: CustomStringConvertible {
     var description: String {
-        return "id: \(identifier), title: \(title), isCompleted: \(isCompleted), parent: \(parent ?? "nil" as CustomStringConvertible), subTasks: \(subTasks)"
+        return "id: \(id), title: \(title), isCompleted: \(isDone), parent: \(parent ?? "nil" as CustomStringConvertible), subTasks: \(subTasks)"
     }
 }

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuInteractor.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuInteractor.swift
@@ -1,0 +1,33 @@
+//
+//  MenuInteractor.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/12/08.
+//
+
+import Foundation
+
+protocol MenuBusinessLogic {
+    
+}
+
+protocol MenuDataStore {
+    var projects: [Project] { get set }
+}
+
+class MenuInteractor: MenuDataStore {
+    
+    let presenter: MenuPresentLogic
+    let worker: MenuWorker
+    var projects: [Project] = []
+    
+    init(presenter: MenuPresentLogic, worker: MenuWorker) {
+        self.presenter = presenter
+        self.worker = worker
+    }
+}
+
+extension MenuInteractor: MenuBusinessLogic {
+
+}
+

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuInteractor.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuInteractor.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol MenuBusinessLogic {
     func fetchProjects()
+    func updateProject(request: MenuModels.UpdateProject.Request)
 }
 
 protocol MenuDataStore {
@@ -37,3 +38,13 @@ extension MenuInteractor: MenuBusinessLogic {
         }
     }
     
+    func updateProject(request: MenuModels.UpdateProject.Request) {
+        let vm = request.project
+        let vmId = vm.id.replacingOccurrences(of: "+", with: "")
+        if let index = projects.firstIndex(where: { $0.id == vmId }) {
+            projects[index].isFavorite = !vm.isFavorite
+            presenter.presentUpdatedProject(response: .init(project: projects[index]))
+        }
+    }
+}
+

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuInteractor.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuInteractor.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol MenuBusinessLogic {
-    
+    func fetchProjects()
 }
 
 protocol MenuDataStore {
@@ -29,5 +29,11 @@ class MenuInteractor: MenuDataStore {
 
 extension MenuInteractor: MenuBusinessLogic {
 
-}
-
+    func fetchProjects() {
+        worker.request(endPoint: .getAll) { [weak self] (projects: [Project]?, error) in
+            let projects = projects ?? []
+            self?.projects = projects
+            self?.presenter.presentProjects(response: .init(projects: projects))
+        }
+    }
+    

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuModels.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuModels.swift
@@ -9,4 +9,60 @@ import Foundation
 
 enum MenuModels {
     
+
+extension MenuModels {
+    
+    enum ProjectSection: Int, Hashable, CaseIterable, CustomStringConvertible {
+        case normal = 0, project
+        var description: String {
+            switch self {
+            case .normal: return ""
+            case .project: return "프로젝트"
+            }
+        }
+    }
+    
+    struct ProjectVM: Hashable {
+        var id: String
+        var title: String
+        var color: String
+        var taskCount: Int
+        var isFavorite: Bool
+        var isHeader: Bool = false
+        
+        init(id: String = UUID().uuidString,
+            title: String = "",
+            color: String = "#BDBDBD",
+            taskCount: Int = 0,
+            isFavorite: Bool = false,
+            isHeader: Bool = false) {
+            
+            self.id = id
+            self.title = title
+            self.color = color
+            self.taskCount = taskCount
+            self.isFavorite = isFavorite
+            self.isHeader = isHeader
+        }
+        
+        init(project: Project, makeFavorite: Bool = false) {
+            self.id = project.id ?? UUID().uuidString
+            self.title = project.title
+            self.color = "#BDBDBD"
+            self.taskCount = project.taskCount
+            self.isFavorite = project.isFavorite ?? false
+            
+            if makeFavorite {
+                self.id += "+"
+            }
+        }
+        
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(id)
+        }
+        
+        static func ==(lhs: Self, rhs: Self) -> Bool {
+            return lhs.id == rhs.id
+        }
+    }
 }

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuModels.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuModels.swift
@@ -56,6 +56,22 @@ enum MenuModels {
         }
     }
     
+    enum UpdateProject {
+        struct Request {
+            var project: ProjectVM
+        }
+        
+        struct Response {
+            var project: Project
+        }
+        
+        struct ViewModel {
+            var favorite: ProjectVM
+            var project: ProjectVM
+        }
+    }
+}
+
 extension MenuModels {
     
     enum ProjectSection: Int, Hashable, CaseIterable, CustomStringConvertible {

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuModels.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuModels.swift
@@ -9,7 +9,53 @@ import Foundation
 
 enum MenuModels {
     
-
+    // MARK: - Usecase
+    
+    enum FetchProjects {
+        struct Request {
+            
+        }
+        
+        struct Response {
+            var projects: [Project]
+        }
+        
+        struct ViewModel {
+            var projects = [ProjectSection: [ProjectVM]]()
+            
+            init(projects origins: [Project]) {
+                self.projects = generateViewModels(for: origins)
+            }
+            
+            func generateViewModels(for projects: [Project]) -> [ProjectSection: [ProjectVM]] {
+                var viewModels = [ProjectSection: [ProjectVM]]()
+                for section in ProjectSection.allCases {
+                    switch section {
+                        case .normal:
+                            viewModels[section] = [ProjectVM(title: "오늘", isHeader: false)]
+                        case .project:
+                            viewModels[section] = [ProjectVM(title: "프로젝트", isHeader: true)]
+                    }
+                }
+                
+                for project in projects {
+                    guard project.title != "오늘" else {
+                        viewModels[.normal]?[0].taskCount = project.taskCount
+                        continue
+                    }
+                    
+                    viewModels[.project]?[0].taskCount += project.taskCount
+                    viewModels[.project]?.append(.init(project: project))
+                    
+                    if project.isFavorite ?? false {
+                        viewModels[.normal]?.append(.init(project: project, makeFavorite: true))
+                    }
+                }
+                return viewModels
+            }
+        }
+    }
+    
 extension MenuModels {
     
     enum ProjectSection: Int, Hashable, CaseIterable, CustomStringConvertible {

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuModels.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuModels.swift
@@ -1,0 +1,12 @@
+//
+//  MenuModels.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/12/08.
+//
+
+import Foundation
+
+enum MenuModels {
+    
+}

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuPresenter.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuPresenter.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol MenuPresentLogic {
     func presentProjects(response: MenuModels.FetchProjects.Response)
+    func presentUpdatedProject(response: MenuModels.UpdateProject.Response)
 }
 
 class MenuPresenter {
@@ -27,3 +28,10 @@ extension MenuPresenter: MenuPresentLogic {
         viewController?.displayFetchedProjects(viewModel: viewModel)
     }
     
+    func presentUpdatedProject(response: MenuModels.UpdateProject.Response) {
+        let vm = MenuModels.ProjectVM(project: response.project)
+        let favorite = MenuModels.ProjectVM(project: response.project, makeFavorite: true)
+        let viewModel = MenuModels.UpdateProject.ViewModel(favorite: favorite, project: vm)
+        viewController?.displayUpdatedProject(viewModel: viewModel)
+    }
+}

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuPresenter.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuPresenter.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol MenuPresentLogic {
-    
+    func presentProjects(response: MenuModels.FetchProjects.Response)
 }
 
 class MenuPresenter {
@@ -22,4 +22,8 @@ class MenuPresenter {
 
 extension MenuPresenter: MenuPresentLogic {
     
-}
+    func presentProjects(response: MenuModels.FetchProjects.Response) {
+        let viewModel = MenuModels.FetchProjects.ViewModel(projects: response.projects)
+        viewController?.displayFetchedProjects(viewModel: viewModel)
+    }
+    

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuPresenter.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuPresenter.swift
@@ -1,0 +1,25 @@
+//
+//  MenuPresenter.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/12/08.
+//
+
+import Foundation
+
+protocol MenuPresentLogic {
+    
+}
+
+class MenuPresenter {
+    
+    weak var viewController: MenuDisplayLogic?
+    
+    init(viewController: MenuDisplayLogic) {
+        self.viewController = viewController
+    }
+}
+
+extension MenuPresenter: MenuPresentLogic {
+    
+}

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuRouter.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuRouter.swift
@@ -1,0 +1,31 @@
+//
+//  MenuRouter.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/12/08.
+//
+
+import Foundation
+
+protocol MenuRoutingLogic {
+    
+}
+
+protocol MenuDataPassing {
+    var dataStore: MenuDataStore { get }
+}
+
+class MenuRouter: MenuDataPassing {
+    
+    let dataStore: MenuDataStore
+    weak var viewController: MenuViewController?
+    
+    init(dataStore: MenuDataStore, viewController: MenuViewController) {
+        self.dataStore = dataStore
+        self.viewController = viewController
+    }
+}
+
+extension MenuRouter: MenuRoutingLogic {
+    
+}

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuRouter.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuRouter.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol MenuRoutingLogic {
-    
+    func routeToTaskList(for project: MenuModels.ProjectVM)
 }
 
 protocol MenuDataPassing {
@@ -28,4 +28,18 @@ class MenuRouter: MenuDataPassing {
 
 extension MenuRouter: MenuRoutingLogic {
     
+    func routeToTaskList(for project: MenuModels.ProjectVM) {
+        let projectId = project.id.replacingOccurrences(of: "+", with: "")
+        
+        let storyboard = viewController?.storyboard
+        guard let projectIndex = dataStore.projects.firstIndex(where: { $0.id == projectId }),
+            let vc = storyboard?.instantiateViewController(identifier: "\(TaskListViewController.self)",
+                                                        creator: { [unowned self] (coder) -> TaskListViewController? in
+            return TaskListViewController(coder: coder, project: self.dataStore.projects[projectIndex])
+        })
+        else {
+            return
+        }
+        viewController?.navigationController?.pushViewController(vc, animated: true)
+    }
 }

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
@@ -205,12 +205,7 @@ extension MenuViewController: UICollectionViewDelegate {
             return
         }
         
-        guard let vc = storyboard?.instantiateViewController(identifier: "\(TaskListViewController.self)", creator: { (coder) -> TaskListViewController? in
-            return TaskListViewController(coder: coder)
-        }) else { return }
-        vc.title = project.title
-        vc.projectTitle = project.title
-        navigationController?.pushViewController(vc, animated: true)
+        rotuer?.routeToTaskList(for: project)
     }
 }
 

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
@@ -197,12 +197,17 @@ extension MenuViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         collectionView.deselectItem(at: indexPath, animated: true)
         
-        let project = dataSource.snapshot().itemIdentifiers[indexPath.item+1]
+        guard let project = dataSource.itemIdentifier(for: indexPath),
+              !project.isHeader
+        else {
+            return
+        }
+        
         guard let vc = storyboard?.instantiateViewController(identifier: "\(TaskListViewController.self)", creator: { (coder) -> TaskListViewController? in
             return TaskListViewController(coder: coder)
         }) else { return }
         vc.title = project.title
-        vc.projectTitle = project.title ?? ""
+        vc.projectTitle = project.title
         navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
@@ -94,7 +94,7 @@ private extension MenuViewController {
     func configureDataSource() {
         dataSource = UICollectionViewDiffableDataSource<Section, ProjectVM>(collectionView: menuCollectionView) {
             (collectionView, indexPath, item) -> UICollectionViewCell? in
-            guard let section = Section(rawValue: indexPath.section) else { fatalError("Unknown section") }
+            guard let section = Section(rawValue: indexPath.section) else { fatalError() }
             switch section {
             case .normal:
                 let cellRegistration = indexPath.row == 0 ? self.configuredNormalCell() : self.configuredProjectCell()

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
@@ -55,6 +55,20 @@ class MenuViewController: UIViewController {
     func configureNavItem() {
         navigationItem.title = "메뉴"
     }
+    
+    // MARK: - Methods
+    
+    private func deleteSnapshot(for items: [ProjectVM]) {
+        var snapshot = dataSource.snapshot()
+        snapshot.deleteItems(items)
+        dataSource.apply(snapshot)
+    }
+    
+    private func appendSnapshot(items: [ProjectVM], to: Section) {
+        var normalSnapshot = dataSource.snapshot(for: .normal)
+        normalSnapshot.append(items)
+        dataSource.apply(normalSnapshot, to: .normal)
+    }
 }
 
 

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuViewController.swift
@@ -7,43 +7,19 @@
 
 import UIKit
 
+protocol MenuDisplayLogic: class {
+}
+
 class MenuViewController: UIViewController {
     
-    /// 임시 property
-    let rootItem = Project(color: nil, title: "프로젝트", taskNum: 0)
-    let normalItem = [Project(color: nil, title: "오늘", taskNum: 4)]
-    var projectItem = [Project(title: "환영합니다👋", taskNum: 16),
-                        Project(color: "#B2CCFF", title: "To Do", taskNum: 8),
-                        Project(color: "#B7F0B1", title: "할고래두 프로젝트🐳", taskNum: 12),
-                        Project(color: "#FFE08C", title: "네이버 웨일 프젝", taskNum: 3),
-                        Project(color: "#FFA7A7", title: "네이버 코테⭐️", taskNum: 10)]
-    
-    struct Project: Hashable {
-        private let identifier = UUID()
-        let title: String?
-        let color: String?
-        let taskNum: Int
-        init(color: String? = "#BDBDBD", title: String? = nil, taskNum: Int = 0) {
-            self.title = title
-            self.color = color
-            self.taskNum = taskNum
-        }
-    }
-    
-    enum Section: Int, Hashable, CaseIterable, CustomStringConvertible {
-        case normal, project
-        var description: String {
-            switch self {
-            case .normal: return ""
-            case .project: return "프로젝트"
-            }
-        }
-    }
+    typealias Section = MenuModels.ProjectSection
+    typealias ProjectVM = MenuModels.ProjectVM
     
     // MARK: - Properties
 
-    var heartProjects = Set<Project>()
-    private var dataSource: UICollectionViewDiffableDataSource<Section, Project>!
+    private var dataSource: UICollectionViewDiffableDataSource<Section, ProjectVM>!
+    private var interactor: MenuBusinessLogic?
+    private var rotuer: (MenuDataPassing & MenuRoutingLogic)?
     
     // MARK: Views
     
@@ -53,18 +29,27 @@ class MenuViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        configureLogic()
         configureNavItem()
         configureCollectionView()
         configureDataSource()
-        applyInitialSnapshots()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         title = "할고래DO"
+        interactor?.fetchProjects()
     }
     
     // MARK: - Initialize
+    
+    func configureLogic() {
+        let presenter = MenuPresenter(viewController: self)
+        let interactor = MenuInteractor(presenter: presenter, worker: MenuWorker(sessionManager: SessionManager(configuration: .default)))
+        self.interactor = interactor
+        self.rotuer = MenuRouter(dataStore: interactor, viewController: self)
+    }
     
     func configureNavItem() {
         navigationItem.title = "메뉴"
@@ -224,4 +209,8 @@ extension MenuViewController: UICollectionViewDelegate {
     }
 }
 
+// MARK: - Menu DisplayLogic
 
+extension MenuViewController: MenuDisplayLogic {
+
+}

--- a/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuWorker.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/Menu/MenuWorker.swift
@@ -1,0 +1,23 @@
+//
+//  MenuWorker.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/12/08.
+//
+
+import Foundation
+
+class MenuWorker {
+    
+    let networkManager: NetworkDispatcher
+    
+    init(sessionManager: SessionManagerProtocol) {
+        networkManager = NetworkManager(sessionManager: sessionManager)
+    }
+    
+    func request<T: Decodable>(endPoint: ProjectEndPoint, completion: @escaping ((T?, NetworkError?) -> Void)) {
+        networkManager.fetchData(endPoint) { (result: T?, error: NetworkError?) in
+            completion(result, error)
+        }
+    }
+}

--- a/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskList.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskList.swift
@@ -11,7 +11,7 @@ class TaskList {
     
     var tasks: [Task] = []
     
-    func task(identifier: UUID, postion: Int, parentPosition: Int?) -> Task? {
+    func task(identifier: String, postion: Int, parentPosition: Int?) -> Task? {
         var superTasks = tasks
         if let parentPosition = parentPosition  {
             superTasks = tasks[parentPosition].subTasks

--- a/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskListViewController.swift
+++ b/iOS/HalgoraeDO/Sources/Scenes/TaskList/TaskListViewController.swift
@@ -16,7 +16,7 @@ class TaskListViewController: UIViewController {
     // MARK: - Properties
     
     /// 임시 property
-    var projectTitle = "할고래DO"
+    private let project: Project
     private var interactor: TaskListBusinessLogic?
     private var router: (TaskListRoutingLogic & TaskListDataPassing)?
     private var dataSource: UICollectionViewDiffableDataSource<String, TaskVM>! = nil
@@ -43,9 +43,19 @@ class TaskListViewController: UIViewController {
     
     // MARK: - View Life Cycle
     
+    init?(coder: NSCoder, project: Project) {
+        self.project = project
+        super.init(coder: coder)
+    }
+    
+    required init?(coder: NSCoder) {
+        self.project = Project(title: "")
+        super.init(coder: coder)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = projectTitle
+        title = project.title
         configureLogic()
         configureCollectionView()
         configureDataSource()
@@ -76,7 +86,7 @@ class TaskListViewController: UIViewController {
         if !editingMode {
             selectedTasks.removeAll()
         }
-        title = editingMode ? "\(selectedTasks.count) 개 선택됨" : projectTitle
+        title = editingMode ? "\(selectedTasks.count) 개 선택됨" : project.title
         taskListCollectionView.isEditing = editingMode
         moreButton.title = editingMode ? "취소" : "More"
         editToolBar.isHidden = !editingMode
@@ -118,7 +128,7 @@ class TaskListViewController: UIViewController {
                 return
             }
             
-            vc.title = self.projectTitle
+            vc.title = self.project.title
             let nav = self.navigationController
             nav?.popViewController(animated: false)
             nav?.pushViewController(vc, animated: false)
@@ -246,7 +256,7 @@ private extension TaskListViewController {
 extension TaskListViewController: TaskListDisplayLogic {
     
     func displayFetchTasks(viewModel: TaskListModels.FetchTasks.ViewModel) {
-        let currentSnapshot = dataSource.snapshot(for: projectTitle)
+        let currentSnapshot = dataSource.snapshot(for: project.title)
         displayTasks = filterCompletedIfNeeded(for: viewModel.displayedTasks)
         var snapShot = snapshot(taskItems: displayTasks)
         for item in snapShot.items {
@@ -258,7 +268,7 @@ extension TaskListViewController: TaskListDisplayLogic {
             
             snapShot.expand([item])
         }
-        dataSource.apply(snapShot, to: projectTitle, animatingDifferences: true)
+        dataSource.apply(snapShot, to: project.title, animatingDifferences: true)
     }
     
     func displayDetail(of task: Task) {
@@ -343,7 +353,7 @@ extension TaskListViewController: UICollectionViewDragDelegate {
     
     private func dragItems(at indexPath: IndexPath) -> [UIDragItem] {
         guard let taskObject = taskListCollectionView.cellForItem(at: indexPath) as? TaskCollectionViewListCell else { return [] }
-        let provider = NSItemProvider(object: taskObject.taskViewModel!.id.uuidString as NSString)
+        let provider = NSItemProvider(object: taskObject.taskViewModel!.id as NSString)
         let dragItem = UIDragItem(itemProvider: provider)
         guard let collectionView = taskListCollectionView else { return [dragItem] }
         let cell = collectionView.cellForItem(at: indexPath)
@@ -400,7 +410,7 @@ extension TaskListViewController: UICollectionViewDropDelegate {
                     }
             
                     let snapShot = dropHelper(displayTasks, dataSource.itemIdentifier(for: sourceIndexPath)!, dataSource.itemIdentifier(for: tempIndex)!)
-                    dataSource.apply(snapShot, to: projectTitle, animatingDifferences: true)
+                    dataSource.apply(snapShot, to: project.title, animatingDifferences: true)
                     coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
                 }
             }

--- a/iOS/HalgoraeDO/Sources/Service/DataRequest.swift
+++ b/iOS/HalgoraeDO/Sources/Service/DataRequest.swift
@@ -9,12 +9,10 @@ import Foundation
 
 protocol DataResponsing {
     
-    associatedtype NetworkResponse
-    
     @discardableResult
-    func responseData(completionHandler: @escaping (Data?, NetworkResponse?) -> Void) -> Self
+    func responseData(completionHandler: @escaping (Data?, String?) -> Void) -> Self
     @discardableResult
-    func responseURL(completionHandler: @escaping (URL?, NetworkResponse?) -> Void) -> Self
+    func responseURL(completionHandler: @escaping (URL?, String?) -> Void) -> Self
 }
 
 class DataRequest {
@@ -44,40 +42,39 @@ class DataRequest {
 }
 
 extension DataRequest: DataResponsing {
-    
     @discardableResult
-    func responseData(completionHandler: @escaping (Data?, NetworkResponse?) -> Void) -> Self {
+    func responseData(completionHandler: @escaping (Data?, String?) -> Void) -> Self {
         session.dataTask(with: request, completionHandler: { (data, response, error) in
             guard error == nil else {
-                completionHandler(nil, .failed)
+                completionHandler(nil, NetworkResponse.failed.rawValue)
                 return
             }
 
             guard let data = data else {
-                completionHandler(nil, .noData)
+                completionHandler(nil, NetworkResponse.noData.rawValue)
                 return
             }
             
-            completionHandler(data, .success)
+            completionHandler(data, NetworkResponse.success.rawValue)
         }).resume()
         
         return self
     }
     
     @discardableResult
-    func responseURL(completionHandler: @escaping (URL?, NetworkResponse?) -> Void) -> Self {
+    func responseURL(completionHandler: @escaping (URL?, String?) -> Void) -> Self {
         session.downloadTask(with: request) { (url, response, error) in
             guard error == nil else {
-                completionHandler(nil, .failed)
+                completionHandler(nil, NetworkResponse.failed.rawValue)
                 return
             }
 
             guard let url = url else {
-                completionHandler(nil, .noData)
+                completionHandler(nil, NetworkResponse.noData.rawValue)
                 return
             }
             
-            completionHandler(url, .success)
+            completionHandler(url, NetworkResponse.success.rawValue)
         }.resume()
         
         return self

--- a/iOS/HalgoraeDO/Sources/Service/EndPoints/ProjectEndPoint.swift
+++ b/iOS/HalgoraeDO/Sources/Service/EndPoints/ProjectEndPoint.swift
@@ -1,0 +1,64 @@
+//
+//  ProjectEndPoint.swift
+//  HalgoraeDO
+//
+//  Created by woong on 2020/12/07.
+//
+
+import Foundation
+
+enum ProjectEndPoint {
+    case getAll
+    case get(projectId: Int)
+    case create(request: Data)
+    case titleUpdate(id: Int, titleData: Data)
+    case update(id: Int, project: Data)
+    case delete(id: Int)
+}
+
+extension ProjectEndPoint: EndPointType {
+    var baseURL: URL {
+        return URL(string: "http://101.101.210.222:3000/api")!
+    }
+
+    var path: String {
+        switch self {
+            case .getAll: return "project"
+            case .get(let id): return "project/\(id)"
+            case .create: return "project"
+            case .titleUpdate(let id, _): return "project/\(id)"
+            case .update(let id, _): return "project/\(id)"
+            case .delete(let id): return "project/\(id)"
+        }
+    }
+
+    var httpMethod: HTTPMethod {
+        switch self {
+            case .getAll: return .get
+            case .get: return .get
+            case .create: return .post
+            case .titleUpdate: return .patch
+            case .update: return .put
+            case .delete: return .delete
+        }
+    }
+
+    var httpTask: HTTPTask {
+        switch self {
+            case .getAll: return (nil, nil)
+            case .get: return (nil, nil)
+            case .create(let body): return (body, nil)
+            case .titleUpdate(_, let titleData): return (titleData, nil)
+            case .update(_, let project): return (project, nil)
+            case .delete: return (nil, nil)
+        }
+    }
+
+    var headers: HTTPHeaders? {
+        return [
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": "Bearer \(ProcessInfo.processInfo.environment["token"] ?? "")"
+        ]
+    }
+}

--- a/iOS/HalgoraeDO/Sources/Service/NetworkManager.swift
+++ b/iOS/HalgoraeDO/Sources/Service/NetworkManager.swift
@@ -8,28 +8,25 @@
 import Foundation
 
 protocol NetworkDispatcher {
-    
-    associatedtype NetworkError
-    
     func fetchData<T: Decodable>(_ endpoint: EndPointType, completion: @escaping (_ data: T?, _ error: NetworkError?) -> Void)
     func fetchDownload(_ endpoint: EndPointType, completion: @escaping (_ url: URL?, _ error: NetworkError?) -> Void)
 }
 
-class NetworkManager<Session: SessionManagerProtocol> {
-    
-    enum NetworkError: Error {
-        case responseFail(Session.Request.NetworkResponse?)
-        case unableToDecode(String?)
-    }
-    
+enum NetworkError: Error {
+    case responseFail(String?)
+    case unableToDecode(String?)
+}
+
+class NetworkManager {
+
     enum RequestType {
         case data
         case url
     }
     
-    let sessionManager: Session
+    let sessionManager: SessionManagerProtocol
     
-    init(sessionManager: Session) {
+    init(sessionManager: SessionManagerProtocol) {
         self.sessionManager = sessionManager
     }
 }
@@ -37,13 +34,13 @@ class NetworkManager<Session: SessionManagerProtocol> {
 // MARK: - NetworkDispatcher
 
 extension NetworkManager: NetworkDispatcher {
-    
+
     func fetchData<T>(_ endpoint: EndPointType, completion: @escaping (_ data: T?, _ error: NetworkError?) -> Void) where T : Decodable {
-        
+
         sessionManager.request(endPoint: endpoint).responseData { (result, response) in
             guard let result = result else {
-                
-                completion(nil, .responseFail(response))
+
+                completion(nil, .responseFail(response as! String))
                 return
             }
 
@@ -57,7 +54,7 @@ extension NetworkManager: NetworkDispatcher {
             }
         }
     }
-    
+
     func fetchDownload(_ endpoint: EndPointType, completion: @escaping (_ url: URL?, _ error: NetworkError?) -> Void) {
         sessionManager.request(endPoint: endpoint).responseURL { (result, response) in
             guard let result = result else {

--- a/iOS/HalgoraeDO/Sources/Service/SessionManager.swift
+++ b/iOS/HalgoraeDO/Sources/Service/SessionManager.swift
@@ -8,19 +8,16 @@
 import Foundation
 
 protocol SessionManagerProtocol {
-    
-    associatedtype Request: DataResponsing
-    
     func request(endPoint: EndPointType,
                  cachePolicy: URLRequest.CachePolicy,
-                 timeoutInterval: TimeInterval) -> Request
+                 timeoutInterval: TimeInterval) -> DataRequest
 }
 
 extension SessionManagerProtocol {
     
     func request(endPoint: EndPointType,
                  cachePolicy: URLRequest.CachePolicy = .reloadIgnoringLocalAndRemoteCacheData,
-                 timeoutInterval: TimeInterval = 10.0) -> Request {
+                 timeoutInterval: TimeInterval = 10.0) -> DataRequest {
         request(endPoint: endPoint, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
     }
 }


### PR DESCRIPTION
### 구현화면
<img src="https://user-images.githubusercontent.com/23303023/101523647-34fc6580-39cc-11eb-948b-a9855fb5567e.gif" width="20%" />

### 작업내용
1. 메뉴에서 API를 연동해 Projects를 패치해서 보여줍니다.
2. 즐겨찾기를 했을 때 옮겨가는 것이 아닌 상단에만 추가/제거 되도록 수정했습니다.
    - 옮기게 되면 순서를 보장할 수 없는 문제가 있었습니다.

### 코멘트
- 아직 프로젝트에 Favorite 변수가 없어서 API 요청은 미구현된 상태입니다. 현재 interactor에서 직접 가공해 바로 present로 보내도록 구현되었습니다.
- 관리함 어쩌죠? ㅎ..