### PR TITLE
서비스 테스트 수정 보완

### DIFF
--- a/iOS/HalgoraeDO/Sources/Service/DataRequest.swift
+++ b/iOS/HalgoraeDO/Sources/Service/DataRequest.swift
@@ -9,6 +9,8 @@ import Foundation
 
 protocol DataResponsing {
     
+    var session: URLSession { get }
+    var request: URLRequest { get }
     @discardableResult
     func responseData(completionHandler: @escaping (Data?, String?) -> Void) -> Self
     @discardableResult

--- a/iOS/HalgoraeDO/Sources/Service/NetworkManager.swift
+++ b/iOS/HalgoraeDO/Sources/Service/NetworkManager.swift
@@ -37,7 +37,7 @@ extension NetworkManager: NetworkDispatcher {
 
     func fetchData<T>(_ endpoint: EndPointType, completion: @escaping (_ data: T?, _ error: NetworkError?) -> Void) where T : Decodable {
 
-        sessionManager.request(endPoint: endpoint).responseData { (result, response) in
+        sessionManager.request(endPoint: endpoint, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 5).responseData { (result, response) in
             guard let result = result else {
 
                 completion(nil, .responseFail(response))
@@ -56,7 +56,7 @@ extension NetworkManager: NetworkDispatcher {
     }
 
     func fetchDownload(_ endpoint: EndPointType, completion: @escaping (_ url: URL?, _ error: NetworkError?) -> Void) {
-        sessionManager.request(endPoint: endpoint).responseURL { (result, response) in
+        sessionManager.request(endPoint: endpoint, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 5).responseURL { (result, response) in
             guard let result = result else {
                 completion(nil, .responseFail(response))
                 return

--- a/iOS/HalgoraeDO/Sources/Service/SessionManager.swift
+++ b/iOS/HalgoraeDO/Sources/Service/SessionManager.swift
@@ -13,15 +13,6 @@ protocol SessionManagerProtocol {
                  timeoutInterval: TimeInterval) -> DataResponsing
 }
 
-extension SessionManagerProtocol {
-    
-    func request(endPoint: EndPointType,
-                 cachePolicy: URLRequest.CachePolicy = .reloadIgnoringLocalAndRemoteCacheData,
-                 timeoutInterval: TimeInterval = 10.0) -> DataRequest {
-        request(endPoint: endPoint, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
-    }
-}
-
 class SessionManager: SessionManagerProtocol {
     
     let session: URLSession

--- a/iOS/HalgoraeDO/Sources/Service/SessionManager.swift
+++ b/iOS/HalgoraeDO/Sources/Service/SessionManager.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol SessionManagerProtocol {
     func request(endPoint: EndPointType,
                  cachePolicy: URLRequest.CachePolicy,
-                 timeoutInterval: TimeInterval) -> DataRequest
+                 timeoutInterval: TimeInterval) -> DataResponsing
 }
 
 extension SessionManagerProtocol {
@@ -32,7 +32,7 @@ class SessionManager: SessionManagerProtocol {
     
     func request(endPoint: EndPointType,
                  cachePolicy: URLRequest.CachePolicy = .reloadIgnoringLocalAndRemoteCacheData,
-                 timeoutInterval: TimeInterval = 10.0) -> DataRequest {
+                 timeoutInterval: TimeInterval = 10.0) -> DataResponsing {
         var url = endPoint.baseURL
         if !endPoint.path.isEmpty {
             url.appendPathComponent(endPoint.path)

--- a/iOS/ServiceTests/Mocks/DataRequestMock.swift
+++ b/iOS/ServiceTests/Mocks/DataRequestMock.swift
@@ -9,6 +9,10 @@ import Foundation
 
 class DataRequestMock: DataResponsing {
     
+    var session = URLSession(configuration: .default)
+    var request = URLRequest(url: URL(string: "https://base.com")!)
+    
+    
     enum NetworkResponse: String {
         case success
         case badURL = "Bad URL"
@@ -30,13 +34,13 @@ class DataRequestMock: DataResponsing {
         self.response = response
     }
     
-    func responseData(completionHandler: @escaping (Data?, NetworkResponse?) -> Void) -> Self {
-        completionHandler(mockData, response)
+    func responseData(completionHandler: @escaping (Data?, String?) -> Void) -> Self {
+        completionHandler(mockData, response?.rawValue)
         return self
     }
     
-    func responseURL(completionHandler: @escaping (URL?, NetworkResponse?) -> Void) -> Self {
-        completionHandler(mockURL, response)
+    func responseURL(completionHandler: @escaping (URL?, String?) -> Void) -> Self {
+        completionHandler(mockURL, response?.rawValue)
         return self
     }
 }

--- a/iOS/ServiceTests/Mocks/SessionManagerMock.swift
+++ b/iOS/ServiceTests/Mocks/SessionManagerMock.swift
@@ -16,9 +16,8 @@ class SessionManagerMock: SessionManagerProtocol {
     }
     
     func request(endPoint: EndPointType,
-                 cachePolicy: URLRequest.CachePolicy = .reloadIgnoringLocalAndRemoteCacheData,
-                 timeoutInterval: TimeInterval = 10.0) -> DataRequestMock {
-        
+                 cachePolicy: URLRequest.CachePolicy,
+                 timeoutInterval: TimeInterval) -> DataResponsing {
         return request
     }
 }

--- a/iOS/ServiceTests/RequestTests.swift
+++ b/iOS/ServiceTests/RequestTests.swift
@@ -19,7 +19,7 @@ class RequestTests: XCTestCase {
         request = URLRequest(url: url)
     }
     
-    func testRequest_request_init_url() {
+    func testURL_init_url() {
         // When
         let dataRequest = DataRequest(session: session, request: request)
         
@@ -27,7 +27,7 @@ class RequestTests: XCTestCase {
         XCTAssertEqual(dataRequest.request.url, url)
     }
     
-    func testRequest_responseData_init_url() {
+    func testURL_inResponseData_success() {
         // Given
         let dataRequest = DataRequest(session: session, request: request)
         
@@ -38,7 +38,7 @@ class RequestTests: XCTestCase {
         XCTAssertEqual(responseRequest.request.url, url)
     }
     
-    func testRequest_responseURL_init_url() {
+    func testURL_inResponseURL_success() {
         // Given
         let dataRequest = DataRequest(session: session, request: request)
         

--- a/iOS/ServiceTests/RequestTests.swift
+++ b/iOS/ServiceTests/RequestTests.swift
@@ -38,6 +38,29 @@ class RequestTests: XCTestCase {
         XCTAssertEqual(responseRequest.request.url, url)
     }
     
+    func testURL_inResponseData_withRootSlash_fail() {
+        // Given
+        let dataRequest = DataRequest(session: session, request: request)
+        
+        // When
+        let responseRequest = dataRequest.responseData { (_, _) in }
+        
+        // Then
+        XCTAssertNotEqual(responseRequest.request.url, URL(string: "https://baseURL.com/")!)
+    }
+    
+    func testURL_inResponseData_withBadURL_fail() {
+        // Given
+        request.url = URL(string: "http://baseURL")!
+        let dataRequest = DataRequest(session: session, request: request)
+        
+        // When
+        let _ = dataRequest.responseData { (_, error) in
+            // Then
+            XCTAssertEqual(error, DataRequest.NetworkResponse.badURL.rawValue)
+        }
+    }
+    
     func testURL_inResponseURL_success() {
         // Given
         let dataRequest = DataRequest(session: session, request: request)
@@ -48,4 +71,6 @@ class RequestTests: XCTestCase {
         // Then
         XCTAssertEqual(responseRequest.request.url, url)
     }
+    
+    
 }


### PR DESCRIPTION
### 작업 내용
1. SessionManagerProtocol의 Request 메소드가 구체 타입이 아닌 추상화된 DataResponsing을 리턴하도록 수정했습니다.
2. 재귀적으로 호출되는 문제를 확인하고 default parameter를 정해주던 SessionManager의 extension을 제거했습니다.
    - default parameter는 SessionManager에서 해줬습니다.
3. 문제가 있던 mock data를 수정해서 테스트가 정상동작하도록 수정했습니다.
