### PR TITLE
'관리함' 프로젝트 이름 변경 후 즐겨찾기 하면 사라지는 버그 해결

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,6 +37,7 @@
     "sass": "^1.19.0",
     "sass-loader": "^8.0.2",
     "vue-cli-plugin-vuetify": "~2.0.7",
+    "vue-cli-plugin-webpack-bundle-analyzer": "~2.0.0",
     "vue-template-compiler": "^2.6.11",
     "vuetify-loader": "^1.3.0"
   }

--- a/client/src/components/home/menu/LeftMenuFavoriteProjectList.vue
+++ b/client/src/components/home/menu/LeftMenuFavoriteProjectList.vue
@@ -7,7 +7,7 @@
         >
         <v-list-item-content class="px-3" :key="managedProject.id">
           <v-list-item-title class="font-14">
-            관리함 <span>{{ managedProject.taskCount }}</span>
+            {{ managedProject.title }} <span>{{ managedProject.taskCount }}</span>
           </v-list-item-title>
         </v-list-item-content>
       </v-list-item>

--- a/client/src/store/project.js
+++ b/client/src/store/project.js
@@ -1,8 +1,6 @@
 import projectAPI from "@/api/project";
 import router from "@/router";
 
-const DEFAULT_PROJECT_TITLE = "관리함";
-
 const state = {
   currentProject: {
     id: "",
@@ -20,15 +18,23 @@ const getters = {
   projectInfoById: (state) => (id) => {
     return state.projectInfos.find((project) => project.id === id);
   },
-  namedProjectInfos: (state) =>
-    state.projectInfos.filter(
-      (project) => project.title !== DEFAULT_PROJECT_TITLE && !project.isFavorite
-    ),
+  namedProjectInfos: (state) => {
+    const managedProject = [...state.projectInfos].sort(
+      (projectA, projectB) => new Date(projectA.createdAt) - new Date(projectB.createdAt)
+    )[0];
+    return state.projectInfos.filter(
+      (project) => project.id !== managedProject.id && !project.isFavorite
+    );
+  },
   favoriteProjectInfos: (state) => {
     return state.projectInfos.filter((project) => project.isFavorite);
   },
-  managedProject: (state) =>
-    state.projectInfos.find((project) => project.title === DEFAULT_PROJECT_TITLE),
+  managedProject: (state) => {
+    const projectInfoSorted = [...state.projectInfos].sort(
+      (projectA, projectB) => new Date(projectA.createdAt) - new Date(projectB.createdAt)
+    );
+    return projectInfoSorted[0];
+  },
   projectList: (state) => state.projectList,
 };
 
@@ -68,6 +74,7 @@ const actions = {
     try {
       await projectAPI.updateProject(projectId, { title });
       await dispatch("fetchCurrentProject", projectId);
+      await dispatch("fetchProjectInfos");
       await dispatch("fetchAllTasks");
     } catch (err) {
       commit("SET_ERROR_ALERT", err.response);

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -6,5 +6,6 @@ module.exports = {
       args[0].title = "할고래DO";
       return args;
     });
+    config.plugins.delete("webpack-bundle-analyzer");
   },
 };

--- a/server/src/services/project.js
+++ b/server/src/services/project.js
@@ -14,6 +14,7 @@ const retrieveProjects = async userId => {
       'color',
       'isFavorite',
       'isList',
+      'createdAt',
       [sequelize.fn('COUNT', sequelize.col('sections.tasks.id')), 'taskCount'],
       [sequelize.col('sections.id'), 'defaultSectionId'],
     ],


### PR DESCRIPTION
### 작업 내용
#### BE
- retriveProject service - JSON 리턴값에 createdAt 칼럼 추가

#### FE
- 관리함 필터링 로직 수정 : createdAt 기준 sort해서 첫번째 프로젝트로 수정

### 이슈번호
close #266 


### 코멘트
- webpack bundle size 분석하는 bundle-analyzer를 설치해서 돌려보았습니다. 나중에 최적화에 사용할 예정입니다!
![Untitled](https://user-images.githubusercontent.com/26531678/107010209-6087aa80-67d9-11eb-91ca-61766b10d059.png)
